### PR TITLE
fix(lib): add missing pkg/lib/http and pkg/lib/stego packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!pkg/lib/
 lib64/
 parts/
 sdist/

--- a/pkg/lib/http/client.go
+++ b/pkg/lib/http/client.go
@@ -1,0 +1,218 @@
+// Package http provides a shared HTTP client for Augustus generators and buffs.
+//
+// This package follows the Chariot backend pattern from
+// modules/chariot/backend/pkg/lib/web/http.go with functional options
+// for configuration and convenience methods for common operations.
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Client wraps http.Client with convenience methods for API requests.
+type Client struct {
+	// Client is the underlying HTTP client.
+	Client *http.Client
+
+	// BaseURL is prepended to all request paths.
+	BaseURL string
+
+	// Headers are default headers sent with every request.
+	Headers map[string]string
+
+	// UserAgent is the User-Agent header value.
+	UserAgent string
+}
+
+// Option configures the Client.
+type Option func(*Client)
+
+// NewClient creates a new HTTP client with the given options.
+func NewClient(opts ...Option) *Client {
+	c := &Client{
+		Client:  &http.Client{},
+		Headers: make(map[string]string),
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+// WithBaseURL sets the base URL for all requests.
+// Paths will be appended to this URL.
+func WithBaseURL(url string) Option {
+	return func(c *Client) {
+		c.BaseURL = strings.TrimSuffix(url, "/")
+	}
+}
+
+// WithHeader adds a default header to all requests.
+func WithHeader(key, value string) Option {
+	return func(c *Client) {
+		c.Headers[key] = value
+	}
+}
+
+// WithTimeout sets the HTTP client timeout.
+func WithTimeout(d time.Duration) Option {
+	return func(c *Client) {
+		c.Client.Timeout = d
+	}
+}
+
+// WithBearerToken sets the Authorization header to "Bearer <token>".
+func WithBearerToken(token string) Option {
+	return func(c *Client) {
+		c.Headers["Authorization"] = fmt.Sprintf("Bearer %s", token)
+	}
+}
+
+// WithUserAgent sets the User-Agent header.
+func WithUserAgent(ua string) Option {
+	return func(c *Client) {
+		c.UserAgent = ua
+	}
+}
+
+// WithHTTPClient sets a custom http.Client.
+func WithHTTPClient(client *http.Client) Option {
+	return func(c *Client) {
+		c.Client = client
+	}
+}
+
+// Response represents an HTTP response with the body already read.
+type Response struct {
+	// StatusCode is the HTTP status code.
+	StatusCode int
+
+	// Headers are the response headers.
+	Headers http.Header
+
+	// Body is the response body.
+	Body []byte
+}
+
+// JSON unmarshals the response body into v.
+func (r *Response) JSON(v any) error {
+	return json.Unmarshal(r.Body, v)
+}
+
+// Do executes a pre-built request with context and default headers.
+func (c *Client) Do(ctx context.Context, req *http.Request) (*Response, error) {
+	// Set context on request
+	req = req.WithContext(ctx)
+
+	// Apply default headers
+	for key, value := range c.Headers {
+		if req.Header.Get(key) == "" {
+			req.Header.Set(key, value)
+		}
+	}
+
+	// Set User-Agent if configured
+	if c.UserAgent != "" && req.Header.Get("User-Agent") == "" {
+		req.Header.Set("User-Agent", c.UserAgent)
+	}
+
+	// Execute request
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	return &Response{
+		StatusCode: resp.StatusCode,
+		Headers:    resp.Header,
+		Body:       body,
+	}, nil
+}
+
+// Get sends a GET request to the specified path.
+func (c *Client) Get(ctx context.Context, path string) (*Response, error) {
+	url := c.buildURL(path)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating GET request: %w", err)
+	}
+
+	return c.Do(ctx, req)
+}
+
+// Post sends a POST request with a JSON body to the specified path.
+func (c *Client) Post(ctx context.Context, path string, body any) (*Response, error) {
+	return c.postWithMethod(ctx, http.MethodPost, path, body)
+}
+
+// Put sends a PUT request with a JSON body to the specified path.
+func (c *Client) Put(ctx context.Context, path string, body any) (*Response, error) {
+	return c.postWithMethod(ctx, http.MethodPut, path, body)
+}
+
+// Delete sends a DELETE request to the specified path.
+func (c *Client) Delete(ctx context.Context, path string) (*Response, error) {
+	url := c.buildURL(path)
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating DELETE request: %w", err)
+	}
+
+	return c.Do(ctx, req)
+}
+
+// postWithMethod sends a request with a JSON body using the specified method.
+func (c *Client) postWithMethod(ctx context.Context, method, path string, body any) (*Response, error) {
+	url := c.buildURL(path)
+
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequest(method, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("creating %s request: %w", method, err)
+	}
+
+	// Set Content-Type for JSON body
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	return c.Do(ctx, req)
+}
+
+// buildURL constructs the full URL from base URL and path.
+func (c *Client) buildURL(path string) string {
+	if c.BaseURL == "" {
+		return path
+	}
+
+	// Ensure path starts with /
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	return c.BaseURL + path
+}

--- a/pkg/lib/http/client_test.go
+++ b/pkg/lib/http/client_test.go
@@ -1,0 +1,257 @@
+// Package http provides a shared HTTP client for Venator generators and buffs.
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewClient_Default(t *testing.T) {
+	client := NewClient()
+
+	if client == nil {
+		t.Fatal("expected non-nil client")
+	}
+	if client.Client == nil {
+		t.Fatal("expected non-nil http.Client")
+	}
+	if client.BaseURL != "" {
+		t.Errorf("expected empty BaseURL, got %q", client.BaseURL)
+	}
+}
+
+func TestNewClient_WithBaseURL(t *testing.T) {
+	client := NewClient(WithBaseURL("https://example.com"))
+
+	if client.BaseURL != "https://example.com" {
+		t.Errorf("expected BaseURL 'https://example.com', got %q", client.BaseURL)
+	}
+}
+
+func TestNewClient_WithHeader(t *testing.T) {
+	client := NewClient(WithHeader("X-Custom", "test-value"))
+
+	if v, ok := client.Headers["X-Custom"]; !ok || v != "test-value" {
+		t.Errorf("expected header X-Custom='test-value', got %v", client.Headers)
+	}
+}
+
+func TestNewClient_WithBearerToken(t *testing.T) {
+	client := NewClient(WithBearerToken("secret-token"))
+
+	if v, ok := client.Headers["Authorization"]; !ok || v != "Bearer secret-token" {
+		t.Errorf("expected Authorization header, got %v", client.Headers)
+	}
+}
+
+func TestNewClient_WithTimeout(t *testing.T) {
+	client := NewClient(WithTimeout(5 * time.Second))
+
+	if client.Client.Timeout != 5*time.Second {
+		t.Errorf("expected timeout 5s, got %v", client.Client.Timeout)
+	}
+}
+
+func TestClient_Get(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"hello"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(WithBaseURL(server.URL))
+	resp, err := client.Get(context.Background(), "/test")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+	if string(resp.Body) != `{"message":"hello"}` {
+		t.Errorf("unexpected body: %s", string(resp.Body))
+	}
+}
+
+func TestClient_Post(t *testing.T) {
+	var receivedBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
+		}
+		_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(WithBaseURL(server.URL))
+	body := map[string]any{"key": "value"}
+	resp, err := client.Post(context.Background(), "/api", body)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+	if receivedBody["key"] != "value" {
+		t.Errorf("expected key=value in body, got %v", receivedBody)
+	}
+}
+
+func TestClient_PostJSON_TypedResponse(t *testing.T) {
+	type Response struct {
+		Message string `json:"message"`
+		Code    int    `json:"code"`
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"success","code":42}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(WithBaseURL(server.URL))
+	resp, err := client.Post(context.Background(), "/api", nil)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result Response
+	if err := resp.JSON(&result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if result.Message != "success" || result.Code != 42 {
+		t.Errorf("unexpected result: %+v", result)
+	}
+}
+
+func TestClient_HeadersPropagated(t *testing.T) {
+	var receivedAuth string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithBaseURL(server.URL),
+		WithBearerToken("my-token"),
+	)
+	_, err := client.Get(context.Background(), "/test")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedAuth != "Bearer my-token" {
+		t.Errorf("expected 'Bearer my-token', got %q", receivedAuth)
+	}
+}
+
+func TestClient_UserAgent(t *testing.T) {
+	var receivedUA string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedUA = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithBaseURL(server.URL),
+		WithUserAgent("Venator/1.0"),
+	)
+	_, err := client.Get(context.Background(), "/test")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedUA != "Venator/1.0" {
+		t.Errorf("expected 'Venator/1.0', got %q", receivedUA)
+	}
+}
+
+func TestClient_Do_CustomRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient(WithBaseURL(server.URL))
+	req, _ := http.NewRequest(http.MethodPut, server.URL+"/update", nil)
+	resp, err := client.Do(context.Background(), req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("expected status 204, got %d", resp.StatusCode)
+	}
+}
+
+func TestClient_ErrorStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal error"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(WithBaseURL(server.URL))
+	resp, err := client.Get(context.Background(), "/fail")
+
+	// Should not return error for non-2xx (caller decides how to handle)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected status 500, got %d", resp.StatusCode)
+	}
+}
+
+func TestClient_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	client := NewClient(WithBaseURL(server.URL))
+	_, err := client.Get(ctx, "/slow")
+
+	if err == nil {
+		t.Fatal("expected error due to cancelled context")
+	}
+}
+
+func TestResponse_JSON_InvalidJSON(t *testing.T) {
+	resp := &Response{
+		Body: []byte(`not valid json`),
+	}
+
+	var result map[string]any
+	err := resp.JSON(&result)
+
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}

--- a/pkg/lib/stego/embed.go
+++ b/pkg/lib/stego/embed.go
@@ -1,0 +1,211 @@
+// Package stego provides steganography utilities for embedding and extracting
+// hidden messages in images using LSB (Least Significant Bit) techniques.
+package stego
+
+import (
+	"encoding/binary"
+	"errors"
+	"image"
+	"image/color"
+)
+
+// LSBEmbed embeds text in an image using least significant bit steganography.
+// The message length is encoded in the first 4 bytes (32 bits), followed by
+// the message data. Each byte of data is spread across 8 pixels (1 bit per pixel).
+//
+// Only the LSB of the RGB channels is modified, preserving visual quality.
+// Alpha channel is not used to avoid transparency artifacts.
+//
+// Returns an error if the image is nil, message is empty, or the message
+// doesn't fit in the available image capacity.
+func LSBEmbed(img image.Image, message string) (image.Image, error) {
+	if img == nil {
+		return nil, errors.New("image cannot be nil")
+	}
+	if message == "" {
+		return nil, errors.New("message cannot be empty")
+	}
+
+	// Calculate capacity: 3 bits per pixel (R, G, B)
+	bounds := img.Bounds()
+	width := bounds.Dx()
+	height := bounds.Dy()
+	pixelCount := width * height
+	capacityBits := pixelCount * 3
+
+	// Message encoding: 4 bytes for length + message bytes
+	// Each byte needs 8 bits
+	messageBytes := []byte(message)
+	requiredBits := (4 + len(messageBytes)) * 8
+
+	if requiredBits > capacityBits {
+		return nil, errors.New("message too large for image capacity")
+	}
+
+	// Create output image (copy dimensions)
+	output := image.NewRGBA(bounds)
+
+	// Copy original image to output
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			output.Set(x, y, img.At(x, y))
+		}
+	}
+
+	// Prepare data to embed: 4-byte length prefix + message
+	lengthBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(lengthBytes, uint32(len(messageBytes)))
+	data := append(lengthBytes, messageBytes...)
+
+	// Embed data using LSB
+	bitIndex := 0
+	for _, byteVal := range data {
+		for bit := 7; bit >= 0; bit-- { // Process bits from MSB to LSB
+			if bitIndex >= capacityBits {
+				return nil, errors.New("exceeded image capacity during embedding")
+			}
+
+			// Calculate pixel coordinates
+			pixelIndex := bitIndex / 3
+			channelIndex := bitIndex % 3
+			x := bounds.Min.X + (pixelIndex % width)
+			y := bounds.Min.Y + (pixelIndex / width)
+
+			// Get current pixel
+			r, g, b, a := output.At(x, y).RGBA()
+			// Convert from uint32 (0-65535) to uint8 (0-255)
+			rByte := uint8(r >> 8)
+			gByte := uint8(g >> 8)
+			bByte := uint8(b >> 8)
+			aByte := uint8(a >> 8)
+
+			// Extract bit to embed
+			bitValue := (byteVal >> bit) & 1
+
+			// Modify LSB of appropriate channel
+			switch channelIndex {
+			case 0: // R channel
+				rByte = (rByte & 0xFE) | bitValue
+			case 1: // G channel
+				gByte = (gByte & 0xFE) | bitValue
+			case 2: // B channel
+				bByte = (bByte & 0xFE) | bitValue
+			}
+
+			// Set modified pixel
+			output.Set(x, y, color.RGBA{R: rByte, G: gByte, B: bByte, A: aByte})
+			bitIndex++
+		}
+	}
+
+	return output, nil
+}
+
+// LSBExtract extracts a hidden message from an image using LSB steganography.
+// Expects the message to be encoded with a 4-byte length prefix followed by
+// the message data, as created by LSBEmbed.
+//
+// Returns an error if the image is nil or the extracted data is invalid.
+func LSBExtract(img image.Image) (string, error) {
+	if img == nil {
+		return "", errors.New("image cannot be nil")
+	}
+
+	bounds := img.Bounds()
+	width := bounds.Dx()
+	height := bounds.Dy()
+	pixelCount := width * height
+	capacityBits := pixelCount * 3
+
+	// Extract length prefix (4 bytes = 32 bits)
+	if capacityBits < 32 {
+		return "", errors.New("image too small to contain message length")
+	}
+
+	lengthBytes := make([]byte, 4)
+	bitIndex := 0
+
+	// Extract 4 bytes for length
+	for byteIdx := 0; byteIdx < 4; byteIdx++ {
+		var byteVal byte
+		for bit := 7; bit >= 0; bit-- {
+			// Calculate pixel coordinates
+			pixelIndex := bitIndex / 3
+			channelIndex := bitIndex % 3
+			x := bounds.Min.X + (pixelIndex % width)
+			y := bounds.Min.Y + (pixelIndex / width)
+
+			// Get pixel
+			r, g, b, _ := img.At(x, y).RGBA()
+			rByte := uint8(r >> 8)
+			gByte := uint8(g >> 8)
+			bByte := uint8(b >> 8)
+
+			// Extract LSB from appropriate channel
+			var bitValue byte
+			switch channelIndex {
+			case 0: // R channel
+				bitValue = rByte & 1
+			case 1: // G channel
+				bitValue = gByte & 1
+			case 2: // B channel
+				bitValue = bByte & 1
+			}
+
+			byteVal |= (bitValue << bit)
+			bitIndex++
+		}
+		lengthBytes[byteIdx] = byteVal
+	}
+
+	// Decode length
+	messageLength := binary.BigEndian.Uint32(lengthBytes)
+
+	// Sanity check length
+	if messageLength > uint32(capacityBits/8-4) {
+		return "", errors.New("invalid message length extracted")
+	}
+	if messageLength == 0 {
+		return "", nil
+	}
+
+	// Extract message bytes
+	messageBytes := make([]byte, messageLength)
+	for byteIdx := uint32(0); byteIdx < messageLength; byteIdx++ {
+		var byteVal byte
+		for bit := 7; bit >= 0; bit-- {
+			if bitIndex >= capacityBits {
+				return "", errors.New("exceeded image capacity during extraction")
+			}
+
+			// Calculate pixel coordinates
+			pixelIndex := bitIndex / 3
+			channelIndex := bitIndex % 3
+			x := bounds.Min.X + (pixelIndex % width)
+			y := bounds.Min.Y + (pixelIndex / width)
+
+			// Get pixel
+			r, g, b, _ := img.At(x, y).RGBA()
+			rByte := uint8(r >> 8)
+			gByte := uint8(g >> 8)
+			bByte := uint8(b >> 8)
+
+			// Extract LSB from appropriate channel
+			var bitValue byte
+			switch channelIndex {
+			case 0: // R channel
+				bitValue = rByte & 1
+			case 1: // G channel
+				bitValue = gByte & 1
+			case 2: // B channel
+				bitValue = bByte & 1
+			}
+
+			byteVal |= (bitValue << bit)
+			bitIndex++
+		}
+		messageBytes[byteIdx] = byteVal
+	}
+
+	return string(messageBytes), nil
+}

--- a/pkg/lib/stego/embed_test.go
+++ b/pkg/lib/stego/embed_test.go
@@ -1,0 +1,169 @@
+package stego
+
+import (
+	"image"
+	"image/color"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLSBEmbed_EmbedsTextInImage verifies LSB embedding works.
+func TestLSBEmbed_EmbedsTextInImage(t *testing.T) {
+	// Create a small test image (10x10 RGBA)
+	img := image.NewRGBA(image.Rect(0, 0, 10, 10))
+	// Fill with white
+	for y := 0; y < 10; y++ {
+		for x := 0; x < 10; x++ {
+			img.Set(x, y, color.RGBA{R: 255, G: 255, B: 255, A: 255})
+		}
+	}
+
+	message := "Hello"
+
+	result, err := LSBEmbed(img, message)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify result is an image
+	bounds := result.Bounds()
+	assert.Equal(t, img.Bounds(), bounds, "embedded image should have same dimensions")
+}
+
+// TestLSBEmbed_ErrorsOnNilImage verifies error handling for nil image.
+func TestLSBEmbed_ErrorsOnNilImage(t *testing.T) {
+	_, err := LSBEmbed(nil, "test")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "image")
+}
+
+// TestLSBEmbed_ErrorsOnEmptyMessage verifies error handling for empty message.
+func TestLSBEmbed_ErrorsOnEmptyMessage(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 10, 10))
+	_, err := LSBEmbed(img, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "message")
+}
+
+// TestLSBEmbed_ErrorsOnMessageTooLarge verifies error when message doesn't fit.
+func TestLSBEmbed_ErrorsOnMessageTooLarge(t *testing.T) {
+	// Create very small image (2x2)
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+
+	// Try to embed a message that's too large
+	// Each pixel can store 3 bits (R, G, B LSBs), so 2x2 = 4 pixels = 12 bits = 1.5 bytes
+	// A message of 10 bytes should fail
+	longMessage := "1234567890"
+
+	_, err := LSBEmbed(img, longMessage)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too large")
+}
+
+// TestLSBExtract_ExtractsEmbeddedText verifies extraction of embedded text.
+func TestLSBExtract_ExtractsEmbeddedText(t *testing.T) {
+	// Create image
+	img := image.NewRGBA(image.Rect(0, 0, 20, 20))
+	for y := 0; y < 20; y++ {
+		for x := 0; x < 20; x++ {
+			img.Set(x, y, color.RGBA{R: 255, G: 255, B: 255, A: 255})
+		}
+	}
+
+	message := "Secret"
+
+	// Embed
+	embedded, err := LSBEmbed(img, message)
+	require.NoError(t, err)
+
+	// Extract
+	extracted, err := LSBExtract(embedded)
+	require.NoError(t, err)
+	assert.Equal(t, message, extracted)
+}
+
+// TestLSBExtract_ErrorsOnNilImage verifies error handling for nil image.
+func TestLSBExtract_ErrorsOnNilImage(t *testing.T) {
+	_, err := LSBExtract(nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "image")
+}
+
+// TestLSBEmbed_ModifiesOnlyLSBs verifies only least significant bits are changed.
+func TestLSBEmbed_ModifiesOnlyLSBs(t *testing.T) {
+	// Create image with known pixel values
+	img := image.NewRGBA(image.Rect(0, 0, 10, 10))
+	// Fill with specific color (even values so LSB is 0)
+	testColor := color.RGBA{R: 200, G: 150, B: 100, A: 255}
+	for y := 0; y < 10; y++ {
+		for x := 0; x < 10; x++ {
+			img.Set(x, y, testColor)
+		}
+	}
+
+	message := "Hi"
+
+	embedded, err := LSBEmbed(img, message)
+	require.NoError(t, err)
+
+	// Check that pixel values changed by at most 1 (LSB flip)
+	rgba, ok := embedded.(*image.RGBA)
+	require.True(t, ok, "embedded image should be RGBA")
+
+	for y := 0; y < 10; y++ {
+		for x := 0; x < 10; x++ {
+			r, g, b, a := rgba.At(x, y).RGBA()
+			// Convert from uint32 (0-65535 range) to uint8 (0-255 range)
+			rByte := uint8(r >> 8)
+			gByte := uint8(g >> 8)
+			bByte := uint8(b >> 8)
+
+			// Each channel should differ by at most 1 from original
+			assert.LessOrEqual(t, abs(int(rByte)-int(testColor.R)), 1)
+			assert.LessOrEqual(t, abs(int(gByte)-int(testColor.G)), 1)
+			assert.LessOrEqual(t, abs(int(bByte)-int(testColor.B)), 1)
+			assert.Equal(t, uint8(a>>8), testColor.A, "alpha should not change")
+		}
+	}
+}
+
+// TestLSBEmbed_RoundTrip verifies embed + extract returns original message.
+func TestLSBEmbed_RoundTrip(t *testing.T) {
+	testCases := []struct {
+		name    string
+		message string
+	}{
+		{"simple", "Test"},
+		{"withspaces", "Hello World"},
+		{"withpunctuation", "Hi! How are you?"},
+		{"numbers", "12345"},
+		{"mixed", "Test123!@#"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			img := image.NewRGBA(image.Rect(0, 0, 30, 30))
+			for y := 0; y < 30; y++ {
+				for x := 0; x < 30; x++ {
+					img.Set(x, y, color.RGBA{R: 128, G: 128, B: 128, A: 255})
+				}
+			}
+
+			embedded, err := LSBEmbed(img, tc.message)
+			require.NoError(t, err)
+
+			extracted, err := LSBExtract(embedded)
+			require.NoError(t, err)
+			assert.Equal(t, tc.message, extracted)
+		})
+	}
+}
+
+// Helper function for absolute value
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}


### PR DESCRIPTION
## Summary
- Add missing `pkg/lib/http` package with shared HTTP client utilities used by the HuggingFace generator
- Add missing `pkg/lib/stego` package with LSB steganography embedding functions used by the steganography probe
- Update `.gitignore` to allow `pkg/lib/` directory (was being caught by Python's `lib/` ignore pattern)

## Test plan
- [x] Verify `make build` compiles successfully
- [ ] Run `make test` to ensure tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)