### PR TITLE
security(ci): add hardened CI workflow and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "ci"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "go"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: '1.25.3'
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@d6238b002a20823d52840fda27e2d4891c5952dc # v4
+        with:
+          version: latest
+          args: --timeout=5m
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, darwin, windows]
+        goarch: [amd64, arm64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: '0'
+        run: |
+          go build -trimpath -ldflags="-s -w" -o augustus-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/augustus


### PR DESCRIPTION
## Summary

Augustus had **zero CI/CD workflows**. This adds a fully hardened CI pipeline from scratch ahead of re-publicizing the repository.

### New files:

**.github/workflows/ci.yml:**
- **Lint**: golangci-lint with 5m timeout
- **Test**: `go test -race` with coverage
- **Build**: Cross-platform matrix (linux/darwin/windows × amd64/arm64)
- `permissions: contents: read` (explicit least-privilege)
- All 3 actions SHA-pinned to immutable commit hashes:
  - `actions/checkout@v4` → `34e114876b0b11c390a56381ad16ebd13914f8d5`
  - `actions/setup-go@v5` → `40f1582b2485089dde7abd97c1529aa768e1baff`
  - `golangci/golangci-lint-action@v4` → `d6238b002a20823d52840fda27e2d4891c5952dc`

**.github/dependabot.yml:**
- Weekly `github-actions` updates (auto-updates SHA pins)
- Weekly `gomod` updates

### What's NOT in this PR (applied separately):
- Secret scanning + push protection (repo setting, applied via API)
- Branch protection already exists ("main" ruleset with team reviewer requirement)
- Default GITHUB_TOKEN already read-only (org-level setting)

Ref: INF2-48, INF2-49, INF2-53, INF2-54

## Test plan
- [ ] CI passes on this PR (lint, test, build jobs)
- [ ] Build matrix produces 6 binaries (3 OS × 2 arch)
- [ ] Dependabot creates initial update PRs within ~1 week