### PR TITLE
Add external contribution notification workflow

### DIFF
--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: praetorian-inc/external-contrib-action@v1
         with:
-          linear-team-id: "43502f93-0130-4cad-b35c-601bc4cc19a0"
+          linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}
           linear-assignee-id: ${{ secrets.LINEAR_ASSIGNEE_ID }}
-          slack-channel-id: "C0A94CLEX8U"
+          slack-channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
         env:
           ORG_MEMBER_CHECK_PAT: ${{ secrets.ORG_MEMBER_CHECK_PAT }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that triggers when a non-org member opens a PR or Issue
- Automatically creates a Linear issue in the Labs team (Triage state) with `external-contribution` label
- Posts a Slack Block Kit notification to #augustus with buttons linking to GitHub and Linear
- Uses `praetorian-inc/external-contrib-action@v1` (org-level secrets already configured)

## How it works

- `pull_request_target` + `issues` events trigger on `opened`
- Checks org membership via GitHub API (SAML-authorized PAT)
- Skips org members and bot accounts silently
- External contributors → Linear issue + Slack notification

## Test plan

- [x] Unit tests passing (28 tests, 4 suites) in external-contrib-action CI
- [x] Integration tested with external-contrib-test repo
- [ ] Verify first real external contribution triggers correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)