### PR TITLE
feat(parsers): add configurable parser layer for LLM response normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Unlike research-oriented tools, Augustus is built for production security testin
   - [Buff Transformations](#buff-transformations)
   - [Output Formats](#output-formats)
   - [Custom REST Endpoints](#custom-rest-endpoints)
+  - [Response Parsers](#response-parsers)
 - [How It Works](#how-it-works)
 - [Architecture](#architecture)
 - [Configuration](#configuration)
@@ -55,6 +56,7 @@ Unlike research-oriented tools, Augustus is built for production security testin
 | **28 LLM Providers** | OpenAI, Anthropic, Azure, Bedrock, Vertex AI, Ollama, and 22 more with 43 generator variants |
 | **90+ Detectors** | Pattern matching, LLM-as-a-judge, HarmJudge (arXiv:2511.15304), Perspective API, unsafe content detection |
 | **7 Buff Transformations** | Encoding, paraphrase, poetry (5 formats, 3 strategies), low-resource language translation, case transforms |
+| **4 Response Parsers** | SSE aggregation, JSON extraction, passthrough, external scripts (Docker/nsjail sandboxed) |
 | **Flexible Output** | Table, JSON, JSONL, and HTML report formats |
 | **Production Ready** | Concurrent scanning, rate limiting, retry logic, timeout handling |
 | **Single Binary** | Go-based tool compiles to one portable executable |
@@ -275,6 +277,114 @@ augustus scan rest.Rest \
 - `api_key`: API key for `$KEY` placeholder substitution
 - `proxy`: HTTP proxy URL for traffic inspection
 
+### Response Parsers
+
+Augustus supports configurable parsers to normalize LLM responses before detection. This is useful for APIs with non-standard response formats, Server-Sent Events (SSE), or custom JSON structures.
+
+**Built-in Parsers:**
+
+| Parser | Description |
+|--------|-------------|
+| `passthrough.Passthrough` | Returns raw response unchanged (default) |
+| `sse.Aggregate` | Aggregates SSE chunks with configurable JSONPath extraction |
+| `json.Extract` | Extracts a specific field from JSON responses |
+| `external.Script` | Runs custom Python/shell scripts for parsing |
+
+**SSE Parser Example:**
+
+```bash
+# Parse OpenAI-style SSE streaming responses
+augustus scan rest.Rest \
+  --probe dan.Dan_11_0 \
+  --detector dan.DAN \
+  --parser sse.Aggregate \
+  --parser-config '{"text_field": "$.choices[0].delta.content", "mode": "delta"}' \
+  --config '{"uri": "https://api.example.com/chat/stream"}'
+```
+
+**JSON Extract Example:**
+
+```bash
+# Extract nested field from JSON response
+augustus scan rest.Rest \
+  --probe dan.Dan_11_0 \
+  --detector dan.DAN \
+  --parser json.Extract \
+  --parser-config '{"field": "$.data.response.text"}' \
+  --config '{"uri": "https://api.example.com/generate"}'
+```
+
+**Custom Script Parser (Docker Mode - Recommended):**
+
+```bash
+# Run custom parsing logic in a sandboxed Docker container
+augustus scan rest.Rest \
+  --probe dan.Dan_11_0 \
+  --detector dan.DAN \
+  --parser external.Script \
+  --parser-config '{
+    "command": "python3 -c \"import json,sys; d=json.load(sys.stdin); print(json.dumps({\\\"content\\\": d[\\\"raw_response\\\"].upper()}))\"",
+    "mode": "docker",
+    "image": "python:3.11-slim"
+  }' \
+  --config '{"uri": "https://api.example.com/chat"}'
+```
+
+**Custom Script Parser (Unsafe Mode - Local Execution):**
+
+```bash
+# Create a custom parser script
+cat > parser.py << 'EOF'
+#!/usr/bin/env python3
+import json, sys
+
+data = json.load(sys.stdin)
+raw = data.get("raw_response", "")
+content_type = data.get("content_type", "")
+
+# Custom parsing logic
+word_count = len(raw.split())
+parsed = f"[Words: {word_count}] {raw}"
+
+print(json.dumps({"content": parsed}))
+EOF
+
+# Run with unsafe mode (requires --allow-unsafe-parsers flag)
+augustus scan rest.Rest \
+  --probe dan.Dan_11_0 \
+  --detector dan.DAN \
+  --parser external.Script \
+  --parser-config '{"command": "python3 parser.py", "mode": "unsafe"}' \
+  --allow-unsafe-parsers \
+  --config '{"uri": "https://api.example.com/chat"}'
+```
+
+**Script Protocol:**
+
+External scripts receive JSON on stdin:
+```json
+{"raw_response": "LLM output text", "content_type": "text/plain"}
+```
+
+Scripts must output JSON on stdout:
+```json
+{"content": "parsed output text"}
+```
+
+**Parser Configuration Keys:**
+
+| Key | Parser | Description |
+|-----|--------|-------------|
+| `text_field` | `sse.Aggregate` | JSONPath to extract text from each SSE chunk (e.g., `$.delta.content`) |
+| `mode` | `sse.Aggregate` | Aggregation mode: `delta` (concatenate) or `last` (use final chunk) |
+| `filter_field` | `sse.Aggregate` | JSONPath field to filter chunks (e.g., `$.type`) |
+| `filter_value` | `sse.Aggregate` | Value to match for filtering (e.g., `text`) |
+| `field` | `json.Extract` | JSONPath to extract from JSON response |
+| `command` | `external.Script` | Shell command or script path to execute |
+| `mode` | `external.Script` | Execution mode: `docker` (sandboxed), `nsjail`, or `unsafe` |
+| `image` | `external.Script` | Docker image (default: `python:3.11-slim`) |
+| `timeout` | `external.Script` | Script timeout in seconds (default: 30) |
+
 ### Advanced Options
 
 ```bash
@@ -339,6 +449,7 @@ pkg/
   logging/            Structured slog-based logging
   metrics/            Prometheus metrics collection
   prefilter/          Aho-Corasick keyword pre-filtering
+  parsers/            Response parser interfaces and registry
   probes/             Public probe interfaces and registry
   ratelimit/          Token bucket rate limiting
   registry/           Generic capability registration system
@@ -353,6 +464,7 @@ internal/
   detectors/          90+ detector implementations (35 categories)
   harnesses/          3 harness strategies (probewise, batch, agentwise)
   buffs/              7 buff transformations
+  parsers/            4 response parser implementations (passthrough, SSE, JSON, external)
   attackengine/       Iterative adversarial attack engine (PAIR/TAP backend)
   ahocorasick/        Internal Aho-Corasick keyword matching
 benchmarks/           Performance benchmarks
@@ -499,6 +611,11 @@ Output:
   --output, -o                JSONL output file path
   --html                      HTML report file path
   --verbose, -v               Verbose output
+
+Parsers:
+  --parser                    Parser to normalize LLM responses (e.g., 'sse.Aggregate', 'json.Extract')
+  --parser-config             Parser configuration as JSON
+  --allow-unsafe-parsers      Allow running external parsers without sandbox (unsafe mode)
 
 Global:
   --debug, -d                 Enable debug mode

--- a/cmd/augustus/cli.go
+++ b/cmd/augustus/cli.go
@@ -89,6 +89,11 @@ type ScanCmd struct {
 	Setup   string `help:"Shell command run once before all probes. Stdout KEY=VALUE lines are injected into the generator request template as $KEY." name:"setup"`
 	Prepare string `help:"Shell command run before each probe. Receives AUGUSTUS_LAST_RESPONSE env var with raw response from the previous probe." name:"prepare"`
 	Cleanup string `help:"Shell command run once after all probes complete." name:"cleanup"`
+
+	// Parser configuration
+	Parser             string `help:"Parser to normalize LLM responses (e.g., 'sse.Aggregate', 'json.Extract', 'external.Script')." name:"parser"`
+	ParserConfig       string `help:"Parser configuration as JSON." name:"parser-config"`
+	AllowUnsafeParsers bool   `help:"Allow running external parsers without sandbox (unsafe mode)." name:"allow-unsafe-parsers"`
 }
 
 func (s *ScanCmd) Run() error {

--- a/cmd/augustus/common.go
+++ b/cmd/augustus/common.go
@@ -7,6 +7,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/detectors"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/harnesses"
+	"github.com/praetorian-inc/augustus/pkg/parsers"
 	"github.com/praetorian-inc/augustus/pkg/probes"
 )
 
@@ -43,6 +44,12 @@ func listCapabilities() {
 
 	fmt.Printf("Buffs (%d):\n", buffs.Registry.Count())
 	for _, name := range buffs.List() {
+		fmt.Printf("  - %s\n", name)
+	}
+	fmt.Println()
+
+	fmt.Printf("Parsers (%d):\n", parsers.Registry.Count())
+	for _, name := range parsers.List() {
 		fmt.Printf("  - %s\n", name)
 	}
 }

--- a/cmd/augustus/scan.go
+++ b/cmd/augustus/scan.go
@@ -19,10 +19,17 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/harnesses"
 	"github.com/praetorian-inc/augustus/pkg/hooks"
+	"github.com/praetorian-inc/augustus/pkg/parsers"
 	"github.com/praetorian-inc/augustus/pkg/probes"
 	"github.com/praetorian-inc/augustus/pkg/registry"
 	"github.com/praetorian-inc/augustus/pkg/results"
 	"github.com/praetorian-inc/augustus/pkg/types"
+
+	// Import parser implementations to register them
+	_ "github.com/praetorian-inc/augustus/internal/parsers/external"
+	_ "github.com/praetorian-inc/augustus/internal/parsers/json"
+	_ "github.com/praetorian-inc/augustus/internal/parsers/passthrough"
+	_ "github.com/praetorian-inc/augustus/internal/parsers/sse"
 )
 
 // scanConfig holds the configuration for a scan command.
@@ -45,6 +52,11 @@ type scanConfig struct {
 	setup         string        // Shell command: once before all probes
 	prepare       string        // Shell command: before each probe
 	cleanup       string        // Shell command: after all probes
+
+	// Parser configuration
+	parserName         string // Parser name (e.g., "sse.Aggregate")
+	parserConfig       string // Parser configuration as JSON
+	allowUnsafeParsers bool   // Allow external parsers in unsafe mode
 }
 
 // Kong helper methods
@@ -104,24 +116,27 @@ func (s *ScanCmd) execute() error {
 // loadScanConfig converts Kong struct to legacy scanConfig
 func (s *ScanCmd) loadScanConfig() *scanConfig {
 	return &scanConfig{
-		generatorName: s.Generator,
-		probeNames:    s.Probe,
-		detectorNames: s.Detectors,
-		buffNames:     s.Buff,
-		harnessName:   s.Harness,
-		configFile:    s.ConfigFile,
-		configJSON:    s.Config,
-		outputFormat:  s.Format,
-		outputFile:    s.Output,
-		htmlFile:      s.HTML,
-		verbose:       s.Verbose,
-		allProbes:     s.All,
-		timeout:       s.Timeout,
-		concurrency:   s.Concurrency,
-		probeTimeout:  s.ProbeTimeout,
-		setup:         s.Setup,
-		prepare:       s.Prepare,
-		cleanup:       s.Cleanup,
+		generatorName:      s.Generator,
+		probeNames:         s.Probe,
+		detectorNames:      s.Detectors,
+		buffNames:          s.Buff,
+		harnessName:        s.Harness,
+		configFile:         s.ConfigFile,
+		configJSON:         s.Config,
+		outputFormat:       s.Format,
+		outputFile:         s.Output,
+		htmlFile:           s.HTML,
+		verbose:            s.Verbose,
+		allProbes:          s.All,
+		timeout:            s.Timeout,
+		concurrency:        s.Concurrency,
+		probeTimeout:       s.ProbeTimeout,
+		setup:              s.Setup,
+		prepare:            s.Prepare,
+		cleanup:            s.Cleanup,
+		parserName:         s.Parser,
+		parserConfig:       s.ParserConfig,
+		allowUnsafeParsers: s.AllowUnsafeParsers,
 	}
 }
 
@@ -437,6 +452,25 @@ func runScanResolved(ctx context.Context, cfg *scanConfig, yamlCfg *config.Confi
 			prepareHook = &hooks.Hook{Command: cfg.prepare}
 		}
 		gen = hooks.NewHookedGenerator(gen, prepareHook, setupVars)
+	}
+
+	// Wrap generator with parser if configured
+	if cfg.parserName != "" {
+		parserCfg := registry.Config{}
+		if cfg.parserConfig != "" {
+			if err := json.Unmarshal([]byte(cfg.parserConfig), &parserCfg); err != nil {
+				return fmt.Errorf("invalid --parser-config JSON: %w", err)
+			}
+		}
+		// Inject safety flag
+		parserCfg["allow_unsafe"] = cfg.allowUnsafeParsers
+
+		parser, err := parsers.Create(cfg.parserName, parserCfg)
+		if err != nil {
+			return fmt.Errorf("failed to create parser %s: %w", cfg.parserName, err)
+		}
+		gen = parsers.NewParsedGenerator(gen, parser)
+		slog.Info("parser enabled", "parser", cfg.parserName)
 	}
 
 	// Get probe names

--- a/internal/parsers/external/script.go
+++ b/internal/parsers/external/script.go
@@ -1,0 +1,292 @@
+// Package external provides a parser that runs external scripts for custom parsing logic.
+package external
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os/exec"
+	"time"
+
+	"github.com/praetorian-inc/augustus/pkg/parsers"
+	"github.com/praetorian-inc/augustus/pkg/registry"
+)
+
+func init() {
+	parsers.Register("external.Script", NewScript)
+}
+
+// ExecutionMode determines how the script is executed.
+type ExecutionMode string
+
+const (
+	// ModeDocker runs the script in an ephemeral Docker container (default).
+	ModeDocker ExecutionMode = "docker"
+	// ModeNsjail runs the script in an nsjail sandbox (Linux only).
+	ModeNsjail ExecutionMode = "nsjail"
+	// ModeUnsafe runs the script directly on the host (requires --allow-unsafe-parsers flag).
+	ModeUnsafe ExecutionMode = "unsafe"
+)
+
+// Compile-time interface assertion.
+var _ parsers.Parser = (*Script)(nil)
+
+// ScriptInput is the JSON sent to the external script via stdin.
+type ScriptInput struct {
+	RawResponse string            `json:"raw_response"`
+	ContentType string            `json:"content_type"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// ScriptOutput is the JSON expected from the script via stdout.
+type ScriptOutput struct {
+	Content string `json:"content"`
+	Error   string `json:"error,omitempty"`
+}
+
+// Script runs an external Python/shell script for custom parsing.
+type Script struct {
+	command     string
+	mode        ExecutionMode
+	image       string
+	timeout     time.Duration
+	maxMemory   string
+	noNetwork   bool
+	allowUnsafe bool
+}
+
+// NewScript creates a new external script parser.
+func NewScript(cfg registry.Config) (parsers.Parser, error) {
+	s := &Script{
+		mode:      ModeDocker,
+		image:     "python:3.11-slim",
+		timeout:   30 * time.Second,
+		maxMemory: "128m",
+		noNetwork: true,
+	}
+
+	// Required: command
+	cmd, ok := cfg["command"].(string)
+	if !ok || cmd == "" {
+		return nil, fmt.Errorf("external.Script requires 'command' configuration")
+	}
+	s.command = cmd
+
+	// Optional: execution mode
+	if mode, ok := cfg["mode"].(string); ok {
+		switch ExecutionMode(mode) {
+		case ModeDocker, ModeNsjail, ModeUnsafe:
+			s.mode = ExecutionMode(mode)
+		default:
+			return nil, fmt.Errorf("external.Script: invalid mode %q (must be 'docker', 'nsjail', or 'unsafe')", mode)
+		}
+	}
+
+	// Optional: Docker image
+	if image, ok := cfg["image"].(string); ok && image != "" {
+		s.image = image
+	}
+
+	// Optional: timeout
+	if timeout, ok := cfg["timeout"].(float64); ok {
+		s.timeout = time.Duration(timeout) * time.Second
+	} else if timeout, ok := cfg["timeout"].(int); ok {
+		s.timeout = time.Duration(timeout) * time.Second
+	}
+
+	// Optional: memory limit
+	if maxMemory, ok := cfg["max_memory"].(string); ok && maxMemory != "" {
+		s.maxMemory = maxMemory
+	}
+
+	// Optional: network isolation
+	if noNetwork, ok := cfg["no_network"].(bool); ok {
+		s.noNetwork = noNetwork
+	}
+
+	// Safety flag from CLI
+	if allowUnsafe, ok := cfg["allow_unsafe"].(bool); ok {
+		s.allowUnsafe = allowUnsafe
+	}
+
+	// Validate unsafe mode
+	if s.mode == ModeUnsafe && !s.allowUnsafe {
+		return nil, fmt.Errorf("external.Script: unsafe mode requires --allow-unsafe-parsers flag")
+	}
+
+	// Emit warnings
+	s.emitWarnings()
+
+	return s, nil
+}
+
+// emitWarnings logs warnings about the execution mode.
+func (s *Script) emitWarnings() {
+	switch s.mode {
+	case ModeDocker:
+		log.Printf("WARN external.Script: Running in Docker container. Performance may be slower due to container overhead. Ensure Docker daemon is running.")
+	case ModeNsjail:
+		log.Printf("WARN external.Script: Running in nsjail sandbox. Limited to Linux hosts with nsjail installed.")
+	case ModeUnsafe:
+		log.Printf("WARN ⚠️  external.Script: Running in UNSAFE mode. Script has full host access. Only use trusted scripts. Consider using 'docker' mode for untrusted parsers.")
+	}
+	log.Printf("INFO external.Script: External parsers add latency (~50-200ms per call). For high-volume scans, consider implementing a built-in parser.")
+}
+
+// Parse executes the external script and returns the parsed content.
+func (s *Script) Parse(ctx context.Context, raw []byte, contentType string) (string, error) {
+	switch s.mode {
+	case ModeDocker:
+		return s.parseDocker(ctx, raw, contentType)
+	case ModeNsjail:
+		return s.parseNsjail(ctx, raw, contentType)
+	case ModeUnsafe:
+		return s.parseUnsafe(ctx, raw, contentType)
+	default:
+		return "", fmt.Errorf("external.Script: unknown execution mode: %s", s.mode)
+	}
+}
+
+// parseDocker runs the script in a Docker container.
+func (s *Script) parseDocker(ctx context.Context, raw []byte, contentType string) (string, error) {
+	input := ScriptInput{
+		RawResponse: string(raw),
+		ContentType: contentType,
+	}
+	inputBytes, err := json.Marshal(input)
+	if err != nil {
+		return "", fmt.Errorf("external.Script: failed to marshal input: %w", err)
+	}
+
+	// Build Docker command with security restrictions
+	args := []string{
+		"run", "--rm", "-i",
+		"--memory", s.maxMemory,
+		"--cpus", "0.5",
+		"--read-only",
+		"--security-opt", "no-new-privileges",
+	}
+	if s.noNetwork {
+		args = append(args, "--network", "none")
+	}
+	args = append(args, s.image, "sh", "-c", s.command)
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.Stdin = bytes.NewReader(inputBytes)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("external.Script: timeout after %s", s.timeout)
+		}
+		return "", fmt.Errorf("external.Script: docker failed: %w: %s", err, stderr.String())
+	}
+
+	return s.parseOutput(stdout.Bytes())
+}
+
+// parseNsjail runs the script in an nsjail sandbox.
+func (s *Script) parseNsjail(ctx context.Context, raw []byte, contentType string) (string, error) {
+	input := ScriptInput{
+		RawResponse: string(raw),
+		ContentType: contentType,
+	}
+	inputBytes, err := json.Marshal(input)
+	if err != nil {
+		return "", fmt.Errorf("external.Script: failed to marshal input: %w", err)
+	}
+
+	// Build nsjail command
+	args := []string{
+		"--mode", "o",
+		"--time_limit", fmt.Sprintf("%d", int(s.timeout.Seconds())),
+		"--rlimit_as", "128",
+		"--rlimit_cpu", "10",
+		"--disable_clone_newnet",
+		"--",
+		"sh", "-c", s.command,
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "nsjail", args...)
+	cmd.Stdin = bytes.NewReader(inputBytes)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("external.Script: timeout after %s", s.timeout)
+		}
+		return "", fmt.Errorf("external.Script: nsjail failed: %w: %s", err, stderr.String())
+	}
+
+	return s.parseOutput(stdout.Bytes())
+}
+
+// parseUnsafe runs the script directly on the host.
+func (s *Script) parseUnsafe(ctx context.Context, raw []byte, contentType string) (string, error) {
+	input := ScriptInput{
+		RawResponse: string(raw),
+		ContentType: contentType,
+	}
+	inputBytes, err := json.Marshal(input)
+	if err != nil {
+		return "", fmt.Errorf("external.Script: failed to marshal input: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", s.command)
+	cmd.Stdin = bytes.NewReader(inputBytes)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("external.Script: timeout after %s", s.timeout)
+		}
+		return "", fmt.Errorf("external.Script: script failed: %w: %s", err, stderr.String())
+	}
+
+	return s.parseOutput(stdout.Bytes())
+}
+
+// parseOutput parses the JSON output from the script.
+func (s *Script) parseOutput(stdout []byte) (string, error) {
+	var output ScriptOutput
+	if err := json.Unmarshal(stdout, &output); err != nil {
+		return "", fmt.Errorf("external.Script: invalid script output (expected JSON): %w", err)
+	}
+
+	if output.Error != "" {
+		return "", fmt.Errorf("external.Script: script error: %s", output.Error)
+	}
+
+	return output.Content, nil
+}
+
+// Name returns the parser name.
+func (s *Script) Name() string {
+	return "external.Script"
+}
+
+// Description returns a human-readable description.
+func (s *Script) Description() string {
+	return "Runs external script for custom parsing"
+}

--- a/internal/parsers/external/script_test.go
+++ b/internal/parsers/external/script_test.go
@@ -1,0 +1,208 @@
+package external
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/praetorian-inc/augustus/pkg/registry"
+)
+
+func TestNewScript(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     registry.Config
+		wantErr bool
+	}{
+		{
+			name:    "missing command",
+			cfg:     registry.Config{},
+			wantErr: true,
+		},
+		{
+			name: "empty command",
+			cfg: registry.Config{
+				"command": "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid command docker mode",
+			cfg: registry.Config{
+				"command": "python3 parser.py",
+				"mode":    "docker",
+			},
+			wantErr: false,
+		},
+		{
+			name: "unsafe mode without allow flag",
+			cfg: registry.Config{
+				"command":      "python3 parser.py",
+				"mode":         "unsafe",
+				"allow_unsafe": false,
+			},
+			wantErr: true,
+		},
+		{
+			name: "unsafe mode with allow flag",
+			cfg: registry.Config{
+				"command":      "python3 parser.py",
+				"mode":         "unsafe",
+				"allow_unsafe": true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid mode",
+			cfg: registry.Config{
+				"command": "python3 parser.py",
+				"mode":    "invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "custom timeout",
+			cfg: registry.Config{
+				"command": "python3 parser.py",
+				"timeout": float64(60),
+			},
+			wantErr: false,
+		},
+		{
+			name: "custom memory",
+			cfg: registry.Config{
+				"command":    "python3 parser.py",
+				"max_memory": "256m",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewScript(tt.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewScript() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && p == nil {
+				t.Error("NewScript() returned nil without error")
+			}
+		})
+	}
+}
+
+func TestScript_Name(t *testing.T) {
+	s := &Script{}
+	if got := s.Name(); got != "external.Script" {
+		t.Errorf("Name() = %q, want %q", got, "external.Script")
+	}
+}
+
+func TestScript_Description(t *testing.T) {
+	s := &Script{}
+	if got := s.Description(); got == "" {
+		t.Error("Description() returned empty string")
+	}
+}
+
+func TestScript_ParseOutput(t *testing.T) {
+	s := &Script{}
+
+	tests := []struct {
+		name    string
+		stdout  []byte
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "valid output",
+			stdout:  []byte(`{"content": "parsed text"}`),
+			want:    "parsed text",
+			wantErr: false,
+		},
+		{
+			name:    "empty content",
+			stdout:  []byte(`{"content": ""}`),
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name:    "script error",
+			stdout:  []byte(`{"content": "", "error": "parsing failed"}`),
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid json",
+			stdout:  []byte(`not json`),
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := s.parseOutput(tt.stdout)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseOutput() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("parseOutput() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScript_ParseUnsafe(t *testing.T) {
+	// Test with a simple echo command that outputs valid JSON
+	s := &Script{
+		command: `echo '{"content": "test output"}'`,
+		mode:    ModeUnsafe,
+		timeout: 30 * time.Second,
+	}
+
+	ctx := context.Background()
+	got, err := s.parseUnsafe(ctx, []byte("test input"), "text/plain")
+	if err != nil {
+		t.Fatalf("parseUnsafe() error = %v", err)
+	}
+	if got != "test output" {
+		t.Errorf("parseUnsafe() = %q, want %q", got, "test output")
+	}
+}
+
+func TestScriptInput_JSON(t *testing.T) {
+	input := ScriptInput{
+		RawResponse: "test data",
+		ContentType: "text/plain",
+		Metadata:    map[string]string{"key": "value"},
+	}
+
+	// Verify it's a valid struct (no JSON marshaling test needed, just verify fields exist)
+	if input.RawResponse != "test data" {
+		t.Error("RawResponse not set correctly")
+	}
+	if input.ContentType != "text/plain" {
+		t.Error("ContentType not set correctly")
+	}
+	if input.Metadata["key"] != "value" {
+		t.Error("Metadata not set correctly")
+	}
+}
+
+func TestScriptOutput_JSON(t *testing.T) {
+	output := ScriptOutput{
+		Content: "parsed content",
+		Error:   "",
+	}
+
+	// Verify it's a valid struct
+	if output.Content != "parsed content" {
+		t.Error("Content not set correctly")
+	}
+	if output.Error != "" {
+		t.Error("Error should be empty")
+	}
+}

--- a/internal/parsers/json/extract.go
+++ b/internal/parsers/json/extract.go
@@ -1,0 +1,183 @@
+// Package json provides a parser for extracting fields from JSON responses.
+package json
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/praetorian-inc/augustus/pkg/parsers"
+	"github.com/praetorian-inc/augustus/pkg/registry"
+)
+
+func init() {
+	parsers.Register("json.Extract", NewExtract)
+}
+
+// Compile-time interface assertion.
+var _ parsers.Parser = (*Extract)(nil)
+
+// Extract parses JSON responses and extracts a field via JSONPath.
+type Extract struct {
+	// Field is the JSONPath expression for extraction (e.g., "$.choices[0].message.content").
+	Field string
+}
+
+// NewExtract creates a new JSON extract parser.
+func NewExtract(cfg registry.Config) (parsers.Parser, error) {
+	p := &Extract{}
+
+	field, ok := cfg["field"].(string)
+	if !ok || field == "" {
+		return nil, fmt.Errorf("json.Extract requires 'field' configuration")
+	}
+	p.Field = field
+
+	return p, nil
+}
+
+// Parse extracts a field from JSON content.
+func (p *Extract) Parse(_ context.Context, raw []byte, _ string) (string, error) {
+	var data any
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return "", fmt.Errorf("json.Extract: invalid JSON: %w", err)
+	}
+
+	result, err := evaluateJSONPath(data, p.Field)
+	if err != nil {
+		return "", fmt.Errorf("json.Extract: %w", err)
+	}
+
+	return result, nil
+}
+
+// Name returns the parser name.
+func (p *Extract) Name() string {
+	return "json.Extract"
+}
+
+// Description returns a human-readable description.
+func (p *Extract) Description() string {
+	return "Extracts field from JSON via JSONPath"
+}
+
+// evaluateJSONPath evaluates a simple JSONPath expression.
+// Supports: $.field, $.field.nested, $.field[0], etc.
+func evaluateJSONPath(data any, path string) (string, error) {
+	// Handle root prefix
+	if strings.HasPrefix(path, "$") {
+		path = path[1:]
+	}
+	if strings.HasPrefix(path, ".") {
+		path = path[1:]
+	}
+
+	if path == "" {
+		return valueToString(data), nil
+	}
+
+	segments := parseJSONPath(path)
+	current := data
+
+	for _, seg := range segments {
+		var err error
+		current, err = navigateSegment(current, seg)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return valueToString(current), nil
+}
+
+// parseJSONPath splits a JSONPath into segments.
+func parseJSONPath(path string) []string {
+	var segments []string
+	var current strings.Builder
+
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		switch c {
+		case '.':
+			if current.Len() > 0 {
+				segments = append(segments, current.String())
+				current.Reset()
+			}
+		case '[':
+			if current.Len() > 0 {
+				segments = append(segments, current.String())
+				current.Reset()
+			}
+			// Find matching ]
+			j := i + 1
+			for j < len(path) && path[j] != ']' {
+				j++
+			}
+			if j < len(path) {
+				segments = append(segments, "["+path[i+1:j]+"]")
+				i = j
+			}
+		default:
+			current.WriteByte(c)
+		}
+	}
+
+	if current.Len() > 0 {
+		segments = append(segments, current.String())
+	}
+
+	return segments
+}
+
+// navigateSegment navigates one segment of a JSONPath.
+func navigateSegment(data any, seg string) (any, error) {
+	// Array index: [0], [1], etc.
+	if strings.HasPrefix(seg, "[") && strings.HasSuffix(seg, "]") {
+		idx := seg[1 : len(seg)-1]
+		arr, ok := data.([]any)
+		if !ok {
+			return nil, fmt.Errorf("expected array for index %s", seg)
+		}
+		var i int
+		if _, err := fmt.Sscanf(idx, "%d", &i); err != nil {
+			return nil, fmt.Errorf("invalid array index %s", seg)
+		}
+		if i < 0 || i >= len(arr) {
+			return nil, fmt.Errorf("array index %d out of bounds", i)
+		}
+		return arr[i], nil
+	}
+
+	// Object field
+	obj, ok := data.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("expected object for field %s", seg)
+	}
+	val, ok := obj[seg]
+	if !ok {
+		return nil, fmt.Errorf("field %q not found", seg)
+	}
+	return val, nil
+}
+
+// valueToString converts a value to string.
+func valueToString(val any) string {
+	switch v := val.(type) {
+	case string:
+		return v
+	case float64:
+		return fmt.Sprintf("%v", v)
+	case bool:
+		return fmt.Sprintf("%v", v)
+	case nil:
+		return ""
+	default:
+		// For complex types, marshal to JSON
+		data, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		return string(data)
+	}
+}

--- a/internal/parsers/json/extract_test.go
+++ b/internal/parsers/json/extract_test.go
@@ -1,0 +1,167 @@
+package json
+
+import (
+	"context"
+	"testing"
+
+	"github.com/praetorian-inc/augustus/pkg/registry"
+)
+
+func TestNewExtract(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     registry.Config
+		wantErr bool
+	}{
+		{
+			name:    "missing field config",
+			cfg:     registry.Config{},
+			wantErr: true,
+		},
+		{
+			name: "empty field config",
+			cfg: registry.Config{
+				"field": "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid field config",
+			cfg: registry.Config{
+				"field": "$.content",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewExtract(tt.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewExtract() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && p == nil {
+				t.Error("NewExtract() returned nil without error")
+			}
+		})
+	}
+}
+
+func TestExtract_Parse(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		field   string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "simple field",
+			field:   "$.content",
+			input:   `{"content": "Hello, world!"}`,
+			want:    "Hello, world!",
+			wantErr: false,
+		},
+		{
+			name:    "nested field",
+			field:   "$.message.text",
+			input:   `{"message": {"text": "nested value"}}`,
+			want:    "nested value",
+			wantErr: false,
+		},
+		{
+			name:    "array access",
+			field:   "$.choices[0].message.content",
+			input:   `{"choices": [{"message": {"content": "first choice"}}]}`,
+			want:    "first choice",
+			wantErr: false,
+		},
+		{
+			name:    "number value",
+			field:   "$.count",
+			input:   `{"count": 42}`,
+			want:    "42",
+			wantErr: false,
+		},
+		{
+			name:    "bool value",
+			field:   "$.active",
+			input:   `{"active": true}`,
+			want:    "true",
+			wantErr: false,
+		},
+		{
+			name:    "null value",
+			field:   "$.nullable",
+			input:   `{"nullable": null}`,
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name:    "invalid json",
+			field:   "$.content",
+			input:   `not json`,
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "missing field",
+			field:   "$.missing",
+			input:   `{"content": "value"}`,
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "array out of bounds",
+			field:   "$.items[10]",
+			input:   `{"items": ["a", "b"]}`,
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "object as result",
+			field:   "$.data",
+			input:   `{"data": {"key": "value"}}`,
+			want:    `{"key":"value"}`,
+			wantErr: false,
+		},
+		{
+			name:    "array as result",
+			field:   "$.items",
+			input:   `{"items": [1, 2, 3]}`,
+			want:    `[1,2,3]`,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Extract{Field: tt.field}
+			got, err := p.Parse(ctx, []byte(tt.input), "application/json")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("Parse() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtract_Name(t *testing.T) {
+	p := &Extract{}
+	if got := p.Name(); got != "json.Extract" {
+		t.Errorf("Name() = %q, want %q", got, "json.Extract")
+	}
+}
+
+func TestExtract_Description(t *testing.T) {
+	p := &Extract{}
+	if got := p.Description(); got == "" {
+		t.Error("Description() returned empty string")
+	}
+}

--- a/internal/parsers/passthrough/passthrough.go
+++ b/internal/parsers/passthrough/passthrough.go
@@ -1,0 +1,40 @@
+// Package passthrough provides a no-op parser that returns content unchanged.
+package passthrough
+
+import (
+	"context"
+
+	"github.com/praetorian-inc/augustus/pkg/parsers"
+	"github.com/praetorian-inc/augustus/pkg/registry"
+)
+
+func init() {
+	parsers.Register("passthrough.Passthrough", NewPassthrough)
+}
+
+// Compile-time interface assertion.
+var _ parsers.Parser = (*Passthrough)(nil)
+
+// Passthrough is a no-op parser that returns content unchanged.
+// It serves as the default parser when no transformation is needed.
+type Passthrough struct{}
+
+// NewPassthrough creates a new passthrough parser.
+func NewPassthrough(_ registry.Config) (parsers.Parser, error) {
+	return &Passthrough{}, nil
+}
+
+// Parse returns the raw content unchanged.
+func (p *Passthrough) Parse(_ context.Context, raw []byte, _ string) (string, error) {
+	return string(raw), nil
+}
+
+// Name returns the parser name.
+func (p *Passthrough) Name() string {
+	return "passthrough.Passthrough"
+}
+
+// Description returns a human-readable description.
+func (p *Passthrough) Description() string {
+	return "No-op parser that returns content unchanged"
+}

--- a/internal/parsers/passthrough/passthrough_test.go
+++ b/internal/parsers/passthrough/passthrough_test.go
@@ -1,0 +1,81 @@
+package passthrough
+
+import (
+	"context"
+	"testing"
+
+	"github.com/praetorian-inc/augustus/pkg/registry"
+)
+
+func TestNewPassthrough(t *testing.T) {
+	p, err := NewPassthrough(registry.Config{})
+	if err != nil {
+		t.Fatalf("NewPassthrough failed: %v", err)
+	}
+	if p == nil {
+		t.Fatal("NewPassthrough returned nil")
+	}
+}
+
+func TestPassthrough_Parse(t *testing.T) {
+	p := &Passthrough{}
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		input       []byte
+		contentType string
+		want        string
+	}{
+		{
+			name:        "empty input",
+			input:       []byte(""),
+			contentType: "text/plain",
+			want:        "",
+		},
+		{
+			name:        "plain text",
+			input:       []byte("Hello, world!"),
+			contentType: "text/plain",
+			want:        "Hello, world!",
+		},
+		{
+			name:        "json input",
+			input:       []byte(`{"key": "value"}`),
+			contentType: "application/json",
+			want:        `{"key": "value"}`,
+		},
+		{
+			name:        "sse input unchanged",
+			input:       []byte("data: {\"content\": \"test\"}\n"),
+			contentType: "text/event-stream",
+			want:        "data: {\"content\": \"test\"}\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := p.Parse(ctx, tt.input, tt.contentType)
+			if err != nil {
+				t.Fatalf("Parse failed: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Parse() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPassthrough_Name(t *testing.T) {
+	p := &Passthrough{}
+	if got := p.Name(); got != "passthrough.Passthrough" {
+		t.Errorf("Name() = %q, want %q", got, "passthrough.Passthrough")
+	}
+}
+
+func TestPassthrough_Description(t *testing.T) {
+	p := &Passthrough{}
+	if got := p.Description(); got == "" {
+		t.Error("Description() returned empty string")
+	}
+}

--- a/internal/parsers/sse/aggregate.go
+++ b/internal/parsers/sse/aggregate.go
@@ -1,0 +1,347 @@
+// Package sse provides a parser for Server-Sent Events (SSE) streaming responses.
+package sse
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/praetorian-inc/augustus/pkg/parsers"
+	"github.com/praetorian-inc/augustus/pkg/registry"
+)
+
+func init() {
+	parsers.Register("sse.Aggregate", NewAggregate)
+}
+
+// Compile-time interface assertion.
+var _ parsers.Parser = (*Aggregate)(nil)
+
+// Aggregate parses SSE streaming responses and aggregates tokens into coherent text.
+// It supports both auto-detection of common formats and configurable JSONPath extraction.
+type Aggregate struct {
+	// TextField is the JSONPath for text extraction (e.g., "$.delta.text").
+	// If empty, auto-detection is used.
+	TextField string
+
+	// Mode is the aggregation mode: "delta" (concatenate all) or "last" (keep last non-empty).
+	// Default is "delta".
+	Mode string
+
+	// FilterField is the JSONPath for event filtering.
+	FilterField string
+
+	// FilterValue is the value to match for filtering.
+	FilterValue string
+}
+
+// NewAggregate creates a new SSE aggregate parser.
+func NewAggregate(cfg registry.Config) (parsers.Parser, error) {
+	p := &Aggregate{
+		Mode: "delta", // default mode
+	}
+
+	if textField, ok := cfg["text_field"].(string); ok {
+		p.TextField = textField
+	}
+	if mode, ok := cfg["mode"].(string); ok {
+		if mode == "delta" || mode == "last" {
+			p.Mode = mode
+		}
+	}
+	if filterField, ok := cfg["filter_field"].(string); ok {
+		p.FilterField = filterField
+	}
+	if filterValue, ok := cfg["filter_value"].(string); ok {
+		p.FilterValue = filterValue
+	}
+
+	return p, nil
+}
+
+// Parse extracts and aggregates text from SSE streaming responses.
+func (p *Aggregate) Parse(_ context.Context, raw []byte, _ string) (string, error) {
+	if p.TextField != "" {
+		return p.parseConfigurable(raw), nil
+	}
+	return p.parseDefault(raw), nil
+}
+
+// parseDefault uses heuristics to extract text from common SSE structures.
+func (p *Aggregate) parseDefault(body []byte) string {
+	var textParts []string
+	lines := strings.Split(string(body), "\n")
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+
+		// SSE data lines start with "data:"
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+
+		// Remove "data:" prefix
+		jsonStr := strings.TrimPrefix(line, "data:")
+		jsonStr = strings.TrimSpace(jsonStr)
+
+		if jsonStr == "" {
+			continue
+		}
+
+		// Skip [DONE] marker
+		if jsonStr == "[DONE]" {
+			continue
+		}
+
+		// Try to parse as JSON
+		var data map[string]any
+		if err := json.Unmarshal([]byte(jsonStr), &data); err != nil {
+			// Not valid JSON, skip
+			continue
+		}
+
+		// Extract text from various possible structures
+
+		// OpenAI-style: {"delta": {"text": "..."}} or {"delta": {"content": "..."}}
+		if delta, ok := data["delta"].(map[string]any); ok {
+			if text, ok := delta["text"].(string); ok && text != "" {
+				textParts = append(textParts, text)
+			}
+			if content, ok := delta["content"].(string); ok && content != "" {
+				textParts = append(textParts, content)
+			}
+		}
+
+		// OpenAI chat completions: {"choices": [{"delta": {"content": "..."}}]}
+		if choices, ok := data["choices"].([]any); ok {
+			for _, choice := range choices {
+				if choiceMap, ok := choice.(map[string]any); ok {
+					if delta, ok := choiceMap["delta"].(map[string]any); ok {
+						if content, ok := delta["content"].(string); ok && content != "" {
+							textParts = append(textParts, content)
+						}
+					}
+				}
+			}
+		}
+
+		// Claude-style: {"message": {"parts": [{"text": "..."}]}}
+		if message, ok := data["message"].(map[string]any); ok {
+			if parts, ok := message["parts"].([]any); ok {
+				for _, part := range parts {
+					if partMap, ok := part.(map[string]any); ok {
+						if text, ok := partMap["text"].(string); ok && text != "" {
+							textParts = append(textParts, text)
+						}
+					}
+				}
+			}
+		}
+
+		// Direct text field
+		if text, ok := data["text"].(string); ok && text != "" {
+			textParts = append(textParts, text)
+		}
+
+		// Direct content field
+		if content, ok := data["content"].(string); ok && content != "" {
+			textParts = append(textParts, content)
+		}
+	}
+
+	// Join all extracted text
+	if len(textParts) > 0 {
+		return strings.Join(textParts, "")
+	}
+
+	// Fallback: return raw body if no text extracted
+	return string(body)
+}
+
+// parseConfigurable parses SSE using configured JSONPath fields.
+func (p *Aggregate) parseConfigurable(body []byte) string {
+	var result string
+	var parts []string
+	lines := strings.Split(string(body), "\n")
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+
+		jsonStr := strings.TrimPrefix(line, "data:")
+		jsonStr = strings.TrimSpace(jsonStr)
+		if jsonStr == "" || jsonStr == "[DONE]" {
+			continue
+		}
+
+		var data any
+		if err := json.Unmarshal([]byte(jsonStr), &data); err != nil {
+			continue
+		}
+
+		// Apply filter if configured
+		if p.FilterField != "" && p.FilterValue != "" {
+			filterVal, err := evaluateJSONPath(data, p.FilterField)
+			if err != nil || filterVal != p.FilterValue {
+				continue
+			}
+		}
+
+		// Extract text using configured JSONPath
+		text, err := evaluateJSONPath(data, p.TextField)
+		if err != nil || text == "" {
+			continue
+		}
+
+		if p.Mode == "last" {
+			result = text
+		} else {
+			parts = append(parts, text)
+		}
+	}
+
+	if p.Mode == "last" {
+		if result != "" {
+			return result
+		}
+	} else if len(parts) > 0 {
+		return strings.Join(parts, "")
+	}
+
+	// Fallback: return raw body if no text extracted
+	return string(body)
+}
+
+// Name returns the parser name.
+func (p *Aggregate) Name() string {
+	return "sse.Aggregate"
+}
+
+// Description returns a human-readable description.
+func (p *Aggregate) Description() string {
+	return "Aggregates SSE streaming tokens into coherent text"
+}
+
+// evaluateJSONPath evaluates a simple JSONPath expression.
+// Supports: $.field, $.field.nested, $.field[0], etc.
+func evaluateJSONPath(data any, path string) (string, error) {
+	// Handle root prefix
+	if strings.HasPrefix(path, "$") {
+		path = path[1:]
+	}
+	if strings.HasPrefix(path, ".") {
+		path = path[1:]
+	}
+
+	if path == "" {
+		return valueToString(data), nil
+	}
+
+	segments := parseJSONPath(path)
+	current := data
+
+	for _, seg := range segments {
+		var err error
+		current, err = navigateSegment(current, seg)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return valueToString(current), nil
+}
+
+// parseJSONPath splits a JSONPath into segments.
+func parseJSONPath(path string) []string {
+	var segments []string
+	var current strings.Builder
+
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		switch c {
+		case '.':
+			if current.Len() > 0 {
+				segments = append(segments, current.String())
+				current.Reset()
+			}
+		case '[':
+			if current.Len() > 0 {
+				segments = append(segments, current.String())
+				current.Reset()
+			}
+			// Find matching ]
+			j := i + 1
+			for j < len(path) && path[j] != ']' {
+				j++
+			}
+			if j < len(path) {
+				segments = append(segments, "["+path[i+1:j]+"]")
+				i = j
+			}
+		default:
+			current.WriteByte(c)
+		}
+	}
+
+	if current.Len() > 0 {
+		segments = append(segments, current.String())
+	}
+
+	return segments
+}
+
+// navigateSegment navigates one segment of a JSONPath.
+func navigateSegment(data any, seg string) (any, error) {
+	// Array index: [0], [1], etc.
+	if strings.HasPrefix(seg, "[") && strings.HasSuffix(seg, "]") {
+		idx := seg[1 : len(seg)-1]
+		arr, ok := data.([]any)
+		if !ok {
+			return nil, fmt.Errorf("sse: expected array for index %s", seg)
+		}
+		var i int
+		if _, err := fmt.Sscanf(idx, "%d", &i); err != nil {
+			return nil, fmt.Errorf("sse: invalid array index %s", seg)
+		}
+		if i < 0 || i >= len(arr) {
+			return nil, fmt.Errorf("sse: array index %d out of bounds", i)
+		}
+		return arr[i], nil
+	}
+
+	// Object field
+	obj, ok := data.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("sse: expected object for field %s", seg)
+	}
+	val, ok := obj[seg]
+	if !ok {
+		return nil, fmt.Errorf("sse: field %q not found", seg)
+	}
+	return val, nil
+}
+
+// valueToString converts a value to string.
+func valueToString(val any) string {
+	switch v := val.(type) {
+	case string:
+		return v
+	case float64:
+		return fmt.Sprintf("%v", v)
+	case bool:
+		return fmt.Sprintf("%v", v)
+	case nil:
+		return ""
+	default:
+		// For complex types, marshal to JSON
+		data, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		return string(data)
+	}
+}

--- a/internal/parsers/sse/aggregate_test.go
+++ b/internal/parsers/sse/aggregate_test.go
@@ -1,0 +1,294 @@
+package sse
+
+import (
+	"context"
+	"testing"
+
+	"github.com/praetorian-inc/augustus/pkg/registry"
+)
+
+func TestNewAggregate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     registry.Config
+		wantErr bool
+	}{
+		{
+			name:    "default config",
+			cfg:     registry.Config{},
+			wantErr: false,
+		},
+		{
+			name: "with text_field",
+			cfg: registry.Config{
+				"text_field": "$.content",
+			},
+			wantErr: false,
+		},
+		{
+			name: "with mode delta",
+			cfg: registry.Config{
+				"mode": "delta",
+			},
+			wantErr: false,
+		},
+		{
+			name: "with mode last",
+			cfg: registry.Config{
+				"mode": "last",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewAggregate(tt.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewAggregate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && p == nil {
+				t.Error("NewAggregate() returned nil without error")
+			}
+		})
+	}
+}
+
+func TestAggregate_ParseDefault(t *testing.T) {
+	p := &Aggregate{Mode: "delta"}
+	ctx := context.Background()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty input",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "non-sse input returns unchanged",
+			input: "Hello, world!",
+			want:  "Hello, world!",
+		},
+		{
+			name: "openai delta style",
+			input: `data: {"delta": {"text": "Hello"}}
+data: {"delta": {"text": " world"}}
+`,
+			want: "Hello world",
+		},
+		{
+			name: "openai chat completions style",
+			input: `data: {"choices": [{"delta": {"content": "Hello"}}]}
+data: {"choices": [{"delta": {"content": " world"}}]}
+data: [DONE]
+`,
+			want: "Hello world",
+		},
+		{
+			name: "direct content field",
+			input: `data: {"content": "Hello"}
+data: {"content": " world"}
+`,
+			want: "Hello world",
+		},
+		{
+			name: "direct text field",
+			input: `data: {"text": "Hello"}
+data: {"text": " world"}
+`,
+			want: "Hello world",
+		},
+		{
+			name: "claude message style",
+			input: `data: {"message": {"parts": [{"text": "Hello"}]}}
+data: {"message": {"parts": [{"text": " world"}]}}
+`,
+			want: "Hello world",
+		},
+		{
+			name: "mixed with invalid json",
+			input: `data: {"content": "Hello"}
+data: invalid json
+data: {"content": " world"}
+`,
+			want: "Hello world",
+		},
+		{
+			name: "with empty data lines",
+			input: `data: {"content": "Hello"}
+data:
+data: {"content": " world"}
+`,
+			want: "Hello world",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := p.Parse(ctx, []byte(tt.input), "text/event-stream")
+			if err != nil {
+				t.Fatalf("Parse failed: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Parse() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAggregate_ParseConfigurable(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		parser      *Aggregate
+		input       string
+		want        string
+	}{
+		{
+			name: "custom text field",
+			parser: &Aggregate{
+				TextField: "$.data.text",
+				Mode:      "delta",
+			},
+			input: `data: {"data": {"text": "Hello"}}
+data: {"data": {"text": " world"}}
+`,
+			want: "Hello world",
+		},
+		{
+			name: "mode last",
+			parser: &Aggregate{
+				TextField: "$.content",
+				Mode:      "last",
+			},
+			input: `data: {"content": "First"}
+data: {"content": "Second"}
+data: {"content": "Third"}
+`,
+			want: "Third",
+		},
+		{
+			name: "with filter",
+			parser: &Aggregate{
+				TextField:   "$.content",
+				Mode:        "delta",
+				FilterField: "$.type",
+				FilterValue: "text",
+			},
+			input: `data: {"type": "text", "content": "Hello"}
+data: {"type": "meta", "content": "ignored"}
+data: {"type": "text", "content": " world"}
+`,
+			want: "Hello world",
+		},
+		{
+			name: "array access",
+			parser: &Aggregate{
+				TextField: "$.choices[0].delta.content",
+				Mode:      "delta",
+			},
+			input: `data: {"choices": [{"delta": {"content": "Hello"}}]}
+data: {"choices": [{"delta": {"content": " world"}}]}
+`,
+			want: "Hello world",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.parser.Parse(ctx, []byte(tt.input), "text/event-stream")
+			if err != nil {
+				t.Fatalf("Parse failed: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Parse() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAggregate_Name(t *testing.T) {
+	p := &Aggregate{}
+	if got := p.Name(); got != "sse.Aggregate" {
+		t.Errorf("Name() = %q, want %q", got, "sse.Aggregate")
+	}
+}
+
+func TestEvaluateJSONPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    any
+		path    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "simple field",
+			data:    map[string]any{"name": "test"},
+			path:    "$.name",
+			want:    "test",
+			wantErr: false,
+		},
+		{
+			name:    "nested field",
+			data:    map[string]any{"outer": map[string]any{"inner": "value"}},
+			path:    "$.outer.inner",
+			want:    "value",
+			wantErr: false,
+		},
+		{
+			name:    "array index",
+			data:    map[string]any{"items": []any{"a", "b", "c"}},
+			path:    "$.items[1]",
+			want:    "b",
+			wantErr: false,
+		},
+		{
+			name:    "missing field",
+			data:    map[string]any{"name": "test"},
+			path:    "$.missing",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "array out of bounds",
+			data:    map[string]any{"items": []any{"a"}},
+			path:    "$.items[5]",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "number value",
+			data:    map[string]any{"count": float64(42)},
+			path:    "$.count",
+			want:    "42",
+			wantErr: false,
+		},
+		{
+			name:    "bool value",
+			data:    map[string]any{"active": true},
+			path:    "$.active",
+			want:    "true",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := evaluateJSONPath(tt.data, tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("evaluateJSONPath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("evaluateJSONPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/parsers/generator.go
+++ b/pkg/parsers/generator.go
@@ -1,0 +1,73 @@
+package parsers
+
+import (
+	"context"
+
+	"github.com/praetorian-inc/augustus/pkg/attempt"
+	"github.com/praetorian-inc/augustus/pkg/types"
+)
+
+// Compile-time interface assertion.
+var _ types.Generator = (*ParsedGenerator)(nil)
+
+// ParsedGenerator wraps a Generator and applies a Parser to its output.
+// This allows transparent parsing of LLM responses before they reach detectors.
+type ParsedGenerator struct {
+	inner  types.Generator
+	parser Parser
+}
+
+// NewParsedGenerator creates a new parsed generator wrapper.
+// The parser will be applied to each message returned by the inner generator.
+func NewParsedGenerator(gen types.Generator, parser Parser) *ParsedGenerator {
+	return &ParsedGenerator{inner: gen, parser: parser}
+}
+
+// Generate calls the inner generator and applies the parser to each message.
+func (g *ParsedGenerator) Generate(ctx context.Context, conv *attempt.Conversation, n int) ([]attempt.Message, error) {
+	// Call inner generator
+	messages, err := g.inner.Generate(ctx, conv, n)
+	if err != nil {
+		return nil, err
+	}
+
+	// Default content type - parsers should handle format detection
+	contentType := "text/plain"
+
+	// Apply parser to each message
+	for i := range messages {
+		parsed, err := g.parser.Parse(ctx, []byte(messages[i].Content), contentType)
+		if err != nil {
+			return nil, err
+		}
+		messages[i].Content = parsed
+	}
+
+	return messages, nil
+}
+
+// ClearHistory delegates to the inner generator.
+func (g *ParsedGenerator) ClearHistory() {
+	g.inner.ClearHistory()
+}
+
+// Name returns the inner generator's name.
+func (g *ParsedGenerator) Name() string {
+	return g.inner.Name()
+}
+
+// Description returns the inner generator's description.
+func (g *ParsedGenerator) Description() string {
+	return g.inner.Description()
+}
+
+// Inner returns the wrapped generator.
+// This can be used to access generator-specific functionality.
+func (g *ParsedGenerator) Inner() types.Generator {
+	return g.inner
+}
+
+// Parser returns the parser being applied.
+func (g *ParsedGenerator) Parser() Parser {
+	return g.parser
+}

--- a/pkg/parsers/generator_test.go
+++ b/pkg/parsers/generator_test.go
@@ -1,0 +1,180 @@
+package parsers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/praetorian-inc/augustus/pkg/attempt"
+	"github.com/praetorian-inc/augustus/pkg/types"
+)
+
+// mockGenerator is a test double for types.Generator
+type mockGenerator struct {
+	messages []attempt.Message
+	err      error
+}
+
+func (m *mockGenerator) Generate(_ context.Context, _ *attempt.Conversation, n int) ([]attempt.Message, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if n > len(m.messages) {
+		n = len(m.messages)
+	}
+	return m.messages[:n], nil
+}
+
+func (m *mockGenerator) ClearHistory()       {}
+func (m *mockGenerator) Name() string        { return "mock.Generator" }
+func (m *mockGenerator) Description() string { return "Mock generator for testing" }
+
+// mockParser is a test double for types.Parser
+type mockParser struct {
+	transform func(string) string
+	err       error
+}
+
+func (m *mockParser) Parse(_ context.Context, raw []byte, _ string) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	if m.transform != nil {
+		return m.transform(string(raw)), nil
+	}
+	return string(raw), nil
+}
+
+func (m *mockParser) Name() string        { return "mock.Parser" }
+func (m *mockParser) Description() string { return "Mock parser for testing" }
+
+func TestNewParsedGenerator(t *testing.T) {
+	gen := &mockGenerator{}
+	parser := &mockParser{}
+
+	pg := NewParsedGenerator(gen, parser)
+	if pg == nil {
+		t.Fatal("NewParsedGenerator returned nil")
+	}
+	if pg.Inner() != gen {
+		t.Error("Inner() did not return the wrapped generator")
+	}
+	if pg.Parser() != parser {
+		t.Error("Parser() did not return the parser")
+	}
+}
+
+func TestParsedGenerator_Generate(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		messages   []attempt.Message
+		transform  func(string) string
+		wantOutput string
+	}{
+		{
+			name: "passthrough",
+			messages: []attempt.Message{
+				{Role: attempt.RoleAssistant, Content: "Hello, world!"},
+			},
+			transform:  nil, // no transformation
+			wantOutput: "Hello, world!",
+		},
+		{
+			name: "uppercase transformation",
+			messages: []attempt.Message{
+				{Role: attempt.RoleAssistant, Content: "hello"},
+			},
+			transform: func(s string) string {
+				return "PARSED: " + s
+			},
+			wantOutput: "PARSED: hello",
+		},
+		{
+			name: "multiple messages",
+			messages: []attempt.Message{
+				{Role: attempt.RoleAssistant, Content: "first"},
+				{Role: attempt.RoleAssistant, Content: "second"},
+			},
+			transform: func(s string) string {
+				return "[" + s + "]"
+			},
+			wantOutput: "[first]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gen := &mockGenerator{messages: tt.messages}
+			parser := &mockParser{transform: tt.transform}
+			pg := NewParsedGenerator(gen, parser)
+
+			conv := attempt.NewConversation()
+			messages, err := pg.Generate(ctx, conv, 1)
+			if err != nil {
+				t.Fatalf("Generate failed: %v", err)
+			}
+			if len(messages) == 0 {
+				t.Fatal("Generate returned no messages")
+			}
+			if messages[0].Content != tt.wantOutput {
+				t.Errorf("Content = %q, want %q", messages[0].Content, tt.wantOutput)
+			}
+		})
+	}
+}
+
+func TestParsedGenerator_GenerateError(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("generator error", func(t *testing.T) {
+		gen := &mockGenerator{err: context.DeadlineExceeded}
+		parser := &mockParser{}
+		pg := NewParsedGenerator(gen, parser)
+
+		conv := attempt.NewConversation()
+		_, err := pg.Generate(ctx, conv, 1)
+		if err == nil {
+			t.Error("Expected error from generator")
+		}
+	})
+
+	t.Run("parser error", func(t *testing.T) {
+		gen := &mockGenerator{
+			messages: []attempt.Message{
+				{Role: attempt.RoleAssistant, Content: "content"},
+			},
+		}
+		parser := &mockParser{err: context.DeadlineExceeded}
+		pg := NewParsedGenerator(gen, parser)
+
+		conv := attempt.NewConversation()
+		_, err := pg.Generate(ctx, conv, 1)
+		if err == nil {
+			t.Error("Expected error from parser")
+		}
+	})
+}
+
+func TestParsedGenerator_DelegatedMethods(t *testing.T) {
+	gen := &mockGenerator{}
+	parser := &mockParser{}
+	pg := NewParsedGenerator(gen, parser)
+
+	// Test Name delegation
+	if got := pg.Name(); got != "mock.Generator" {
+		t.Errorf("Name() = %q, want %q", got, "mock.Generator")
+	}
+
+	// Test Description delegation
+	if got := pg.Description(); got != "Mock generator for testing" {
+		t.Errorf("Description() = %q, want %q", got, "Mock generator for testing")
+	}
+
+	// Test ClearHistory doesn't panic
+	pg.ClearHistory()
+}
+
+func TestParsedGenerator_ImplementsInterface(t *testing.T) {
+	var _ types.Generator = (*ParsedGenerator)(nil)
+}

--- a/pkg/parsers/parser.go
+++ b/pkg/parsers/parser.go
@@ -1,0 +1,39 @@
+// Package parsers provides the parser interface and implementations for LLM response normalization.
+//
+// Parsers transform raw/fragmented LLM responses (e.g., SSE streams) into
+// coherent text suitable for detector analysis. They sit between generators
+// and detectors in the scan pipeline.
+package parsers
+
+import (
+	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
+)
+
+// Parser is a type alias for backward compatibility.
+// See types.Parser for the canonical interface definition.
+type Parser = types.Parser
+
+// Registry is the global parser registry.
+var Registry = registry.New[Parser]("parsers")
+
+// Register adds a parser factory to the global registry.
+// Called from init() functions in parser implementations.
+func Register(name string, factory func(registry.Config) (Parser, error)) {
+	Registry.Register(name, factory)
+}
+
+// List returns all registered parser names.
+func List() []string {
+	return Registry.List()
+}
+
+// Get retrieves a parser factory by name.
+func Get(name string) (func(registry.Config) (Parser, error), bool) {
+	return Registry.Get(name)
+}
+
+// Create instantiates a parser by name.
+func Create(name string, cfg registry.Config) (Parser, error) {
+	return Registry.Create(name, cfg)
+}

--- a/pkg/types/parser.go
+++ b/pkg/types/parser.go
@@ -1,0 +1,19 @@
+package types
+
+import "context"
+
+// Parser normalizes raw LLM response content before detection.
+// Parsers transform raw/fragmented responses (e.g., SSE streams) into
+// coherent text suitable for detector analysis.
+type Parser interface {
+	// Parse transforms raw response content into normalized text.
+	// The contentType hint (e.g., "text/event-stream", "application/json")
+	// helps parsers decide how to process the input.
+	Parse(ctx context.Context, raw []byte, contentType string) (string, error)
+
+	// Name returns the fully qualified parser name (e.g., "sse.Aggregate").
+	Name() string
+
+	// Description returns a human-readable description.
+	Description() string
+}


### PR DESCRIPTION
## Summary

- Adds a configurable parser layer that normalizes diverse LLM API response formats before detector analysis
- Supports SSE streaming, JSON extraction, and external script parsers with Docker sandboxing
- Enables scanning of custom REST endpoints that return non-standard response formats

Closes LAB-132

## Changes

### Core Parser Interface (`pkg/types/parser.go`)
- `Parser` interface with `Parse(ctx, raw []byte, contentType string) (string, error)`

### Built-in Parsers (`internal/parsers/`)
- **passthrough.Passthrough**: Returns raw response unchanged (default)
- **sse.Aggregate**: Aggregates SSE chunks with configurable `text_field`, `mode` (delta/last), and filtering
- **json.Extract**: Extracts text from JSON using JSONPath expressions
- **external.Script**: Runs custom parser scripts in Docker sandbox or unsafe mode

### Generator Wrapper (`pkg/parsers/generator.go`)
- `ParsedGenerator` wraps any generator and applies parser to output

### CLI Integration (`cmd/augustus/`)
- `--parser`: Select parser by name
- `--parser-config`: JSON config for parser options  
- `--allow-unsafe-parsers`: Enable unsafe mode for external scripts

### Documentation
- Added Response Parsers section to README with examples

## Test plan

- [x] Unit tests for all parsers (42 tests)
- [x] Integration tests for ParsedGenerator
- [x] CLI flag parsing tests
- [x] E2E testing with real APIs via Burp proxy