### PR TITLE
fix(rest): add backward-compatible key aliases for Guard GeneratorConfig

### DIFF
--- a/internal/generators/rest/config.go
+++ b/internal/generators/rest/config.go
@@ -47,10 +47,14 @@ func DefaultConfig() Config {
 func ConfigFromMap(m registry.Config) (Config, error) {
 	cfg := DefaultConfig()
 
-	// Required: URI
+	// Required: URI (also accept "endpoint" as alias for compatibility with GeneratorConfig)
 	uri, err := registry.RequireString(m, "uri")
 	if err != nil {
-		return cfg, fmt.Errorf("rest generator requires 'uri' configuration")
+		endpoint, endpointErr := registry.RequireString(m, "endpoint")
+		if endpointErr != nil {
+			return cfg, fmt.Errorf("rest generator requires 'uri' or 'endpoint' configuration")
+		}
+		uri = endpoint
 	}
 	cfg.URI = uri
 
@@ -67,14 +71,26 @@ func ConfigFromMap(m registry.Config) (Config, error) {
 		}
 	}
 
-	// Optional: request template
+	// Optional: request template (also accept "body" as alias for compatibility with GeneratorConfig)
 	cfg.ReqTemplate = registry.GetString(m, "req_template", cfg.ReqTemplate)
+	if _, hasReqTemplate := m["req_template"]; !hasReqTemplate {
+		if body := registry.GetString(m, "body", ""); body != "" {
+			cfg.ReqTemplate = body
+		}
+	}
 
 	// Optional: response JSON parsing
 	if responseJSON, ok := m["response_json"].(bool); ok {
 		cfg.ResponseJSON = responseJSON
 	}
 	cfg.ResponseJSONField = registry.GetString(m, "response_json_field", "")
+	// Also accept "response_path" as alias for compatibility with GeneratorConfig
+	if cfg.ResponseJSONField == "" {
+		if responsePath := registry.GetString(m, "response_path", ""); responsePath != "" {
+			cfg.ResponseJSONField = responsePath
+			cfg.ResponseJSON = true
+		}
+	}
 
 	// Validate JSON response configuration
 	if cfg.ResponseJSON && cfg.ResponseJSONField == "" {

--- a/internal/generators/rest/config.go
+++ b/internal/generators/rest/config.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/praetorian-inc/augustus/pkg/registry"
@@ -55,6 +56,9 @@ func ConfigFromMap(m registry.Config) (Config, error) {
 			return cfg, fmt.Errorf("rest generator requires 'uri' or 'endpoint' configuration")
 		}
 		uri = endpoint
+	} else if endpoint, _ := registry.RequireString(m, "endpoint"); endpoint != "" && endpoint != uri {
+		slog.Warn("both 'uri' and 'endpoint' specified; using 'uri'",
+			"uri", uri, "endpoint", endpoint)
 	}
 	cfg.URI = uri
 
@@ -77,9 +81,13 @@ func ConfigFromMap(m registry.Config) (Config, error) {
 		if body := registry.GetString(m, "body", ""); body != "" {
 			cfg.ReqTemplate = body
 		}
+	} else if body := registry.GetString(m, "body", ""); body != "" && body != cfg.ReqTemplate {
+		slog.Warn("both 'req_template' and 'body' specified; using 'req_template'",
+			"req_template", cfg.ReqTemplate, "body", body)
 	}
 
 	// Optional: response JSON parsing
+	_, responseJSONExplicit := m["response_json"].(bool)
 	if responseJSON, ok := m["response_json"].(bool); ok {
 		cfg.ResponseJSON = responseJSON
 	}
@@ -88,8 +96,16 @@ func ConfigFromMap(m registry.Config) (Config, error) {
 	if cfg.ResponseJSONField == "" {
 		if responsePath := registry.GetString(m, "response_path", ""); responsePath != "" {
 			cfg.ResponseJSONField = responsePath
-			cfg.ResponseJSON = true
+			if responseJSONExplicit && !cfg.ResponseJSON {
+				slog.Warn("'response_path' would enable JSON parsing, but 'response_json' is explicitly false; respecting 'response_json: false'",
+					"response_path", responsePath)
+			} else {
+				cfg.ResponseJSON = true
+			}
 		}
+	} else if responsePath := registry.GetString(m, "response_path", ""); responsePath != "" && responsePath != cfg.ResponseJSONField {
+		slog.Warn("both 'response_json_field' and 'response_path' specified; using 'response_json_field'",
+			"response_json_field", cfg.ResponseJSONField, "response_path", responsePath)
 	}
 
 	// Validate JSON response configuration

--- a/internal/generators/rest/config_test.go
+++ b/internal/generators/rest/config_test.go
@@ -307,6 +307,22 @@ func TestConfigFromMap_ResponseJSONFieldTakesPrecedenceOverResponsePath(t *testi
 	assert.Equal(t, "canonical_field", cfg.ResponseJSONField, "response_json_field should take precedence over response_path")
 }
 
+// TestConfigFromMap_ResponsePathRespectsExplicitResponseJSONFalse verifies that
+// when "response_path" is used alongside an explicit "response_json": false,
+// the explicit false is respected (ResponseJSON stays false).
+func TestConfigFromMap_ResponsePathRespectsExplicitResponseJSONFalse(t *testing.T) {
+	m := registry.Config{
+		"uri":           "https://api.example.com",
+		"response_json": false,
+		"response_path": "choices[0].text",
+	}
+
+	cfg, err := ConfigFromMap(m)
+	require.NoError(t, err, "ConfigFromMap should succeed")
+	assert.Equal(t, "choices[0].text", cfg.ResponseJSONField, "response_path should still set the field")
+	assert.False(t, cfg.ResponseJSON, "explicit response_json: false should be respected despite response_path alias")
+}
+
 func TestFunctionalOptions_SSE(t *testing.T) {
 	cfg := ApplyOptions(DefaultConfig(),
 		WithURI("https://test.com/api"),

--- a/internal/generators/rest/config_test.go
+++ b/internal/generators/rest/config_test.go
@@ -227,6 +227,86 @@ func TestConfigFromMap_SSEFilterValueWithoutField(t *testing.T) {
 	assert.Contains(t, err.Error(), "sse_filter_field and sse_filter_value must both be set")
 }
 
+// TestConfigFromMap_EndpointAlias verifies that "endpoint" works as an alias for "uri".
+func TestConfigFromMap_EndpointAlias(t *testing.T) {
+	m := registry.Config{
+		"endpoint": "https://api.example.com/chat",
+	}
+
+	cfg, err := ConfigFromMap(m)
+	require.NoError(t, err, "ConfigFromMap with 'endpoint' key should succeed")
+	assert.Equal(t, "https://api.example.com/chat", cfg.URI)
+}
+
+// TestConfigFromMap_BodyAlias verifies that "body" works as an alias for "req_template".
+func TestConfigFromMap_BodyAlias(t *testing.T) {
+	m := registry.Config{
+		"uri":  "https://api.example.com",
+		"body": `{"prompt":"$INPUT"}`,
+	}
+
+	cfg, err := ConfigFromMap(m)
+	require.NoError(t, err, "ConfigFromMap with 'body' key should succeed")
+	assert.Equal(t, `{"prompt":"$INPUT"}`, cfg.ReqTemplate)
+}
+
+// TestConfigFromMap_ResponsePathAlias verifies that "response_path" works as an
+// alias for "response_json_field" and implicitly enables ResponseJSON.
+func TestConfigFromMap_ResponsePathAlias(t *testing.T) {
+	m := registry.Config{
+		"uri":           "https://api.example.com",
+		"response_path": "choices[0].text",
+	}
+
+	cfg, err := ConfigFromMap(m)
+	require.NoError(t, err, "ConfigFromMap with 'response_path' key should succeed")
+	assert.Equal(t, "choices[0].text", cfg.ResponseJSONField)
+	assert.True(t, cfg.ResponseJSON, "response_path alias should enable ResponseJSON")
+}
+
+// TestConfigFromMap_URITakesPrecedenceOverEndpoint verifies that when both "uri"
+// and "endpoint" keys are present, "uri" wins.
+func TestConfigFromMap_URITakesPrecedenceOverEndpoint(t *testing.T) {
+	m := registry.Config{
+		"uri":      "https://canonical.example.com",
+		"endpoint": "https://alias.example.com",
+	}
+
+	cfg, err := ConfigFromMap(m)
+	require.NoError(t, err)
+	assert.Equal(t, "https://canonical.example.com", cfg.URI, "uri should take precedence over endpoint")
+}
+
+// TestConfigFromMap_ReqTemplateTakesPrecedenceOverBody verifies that when both
+// "req_template" and "body" are present, "req_template" wins.
+func TestConfigFromMap_ReqTemplateTakesPrecedenceOverBody(t *testing.T) {
+	m := registry.Config{
+		"uri":          "https://api.example.com",
+		"req_template": `{"from":"req_template"}`,
+		"body":         `{"from":"body"}`,
+	}
+
+	cfg, err := ConfigFromMap(m)
+	require.NoError(t, err)
+	assert.Equal(t, `{"from":"req_template"}`, cfg.ReqTemplate, "req_template should take precedence over body")
+}
+
+// TestConfigFromMap_ResponseJSONFieldTakesPrecedenceOverResponsePath verifies
+// that when both "response_json_field" and "response_path" are present,
+// "response_json_field" wins.
+func TestConfigFromMap_ResponseJSONFieldTakesPrecedenceOverResponsePath(t *testing.T) {
+	m := registry.Config{
+		"uri":                 "https://api.example.com",
+		"response_json":       true,
+		"response_json_field": "canonical_field",
+		"response_path":       "alias_field",
+	}
+
+	cfg, err := ConfigFromMap(m)
+	require.NoError(t, err)
+	assert.Equal(t, "canonical_field", cfg.ResponseJSONField, "response_json_field should take precedence over response_path")
+}
+
 func TestFunctionalOptions_SSE(t *testing.T) {
 	cfg := ApplyOptions(DefaultConfig(),
 		WithURI("https://test.com/api"),

--- a/internal/generators/rest/rest.go
+++ b/internal/generators/rest/rest.go
@@ -110,11 +110,13 @@ func NewRest(cfg registry.Config) (generators.Generator, error) {
 		skipCodes:      make(map[int]bool),
 	}
 
-	// Required: URI
+	// Required: URI (also accept "endpoint" as alias for compatibility with GeneratorConfig)
 	if uri, ok := cfg["uri"].(string); ok && uri != "" {
 		r.uri = uri
+	} else if endpoint, ok := cfg["endpoint"].(string); ok && endpoint != "" {
+		r.uri = endpoint
 	} else {
-		return nil, fmt.Errorf("rest generator requires 'uri' configuration")
+		return nil, fmt.Errorf("rest generator requires 'uri' or 'endpoint' configuration")
 	}
 
 	// Optional: HTTP method
@@ -139,9 +141,11 @@ func NewRest(cfg registry.Config) (generators.Generator, error) {
 		}
 	}
 
-	// Optional: Request template
+	// Optional: Request template (also accept "body" as alias for compatibility with GeneratorConfig)
 	if tmpl, ok := cfg["req_template"].(string); ok {
 		r.reqTemplate = tmpl
+	} else if body, ok := cfg["body"].(string); ok {
+		r.reqTemplate = body
 	}
 
 	// Optional: JSON request template object
@@ -158,6 +162,9 @@ func NewRest(cfg registry.Config) (generators.Generator, error) {
 	}
 	if responseJSONField, ok := cfg["response_json_field"].(string); ok {
 		r.responseJSONField = responseJSONField
+	} else if responsePath, ok := cfg["response_path"].(string); ok {
+		r.responseJSONField = responsePath
+		r.responseJSON = true
 	}
 
 	// Validate JSON response configuration

--- a/internal/generators/rest/rest.go
+++ b/internal/generators/rest/rest.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -113,6 +114,10 @@ func NewRest(cfg registry.Config) (generators.Generator, error) {
 	// Required: URI (also accept "endpoint" as alias for compatibility with GeneratorConfig)
 	if uri, ok := cfg["uri"].(string); ok && uri != "" {
 		r.uri = uri
+		if endpoint, ok := cfg["endpoint"].(string); ok && endpoint != "" && endpoint != uri {
+			slog.Warn("both 'uri' and 'endpoint' specified; using 'uri'",
+				"uri", uri, "endpoint", endpoint)
+		}
 	} else if endpoint, ok := cfg["endpoint"].(string); ok && endpoint != "" {
 		r.uri = endpoint
 	} else {
@@ -144,6 +149,10 @@ func NewRest(cfg registry.Config) (generators.Generator, error) {
 	// Optional: Request template (also accept "body" as alias for compatibility with GeneratorConfig)
 	if tmpl, ok := cfg["req_template"].(string); ok {
 		r.reqTemplate = tmpl
+		if body, ok := cfg["body"].(string); ok && body != tmpl {
+			slog.Warn("both 'req_template' and 'body' specified; using 'req_template'",
+				"req_template", tmpl, "body", body)
+		}
 	} else if body, ok := cfg["body"].(string); ok {
 		r.reqTemplate = body
 	}
@@ -157,14 +166,24 @@ func NewRest(cfg registry.Config) (generators.Generator, error) {
 	}
 
 	// Optional: Response parsing
+	_, responseJSONExplicit := cfg["response_json"].(bool)
 	if responseJSON, ok := cfg["response_json"].(bool); ok {
 		r.responseJSON = responseJSON
 	}
 	if responseJSONField, ok := cfg["response_json_field"].(string); ok {
 		r.responseJSONField = responseJSONField
+		if responsePath, ok := cfg["response_path"].(string); ok && responsePath != responseJSONField {
+			slog.Warn("both 'response_json_field' and 'response_path' specified; using 'response_json_field'",
+				"response_json_field", responseJSONField, "response_path", responsePath)
+		}
 	} else if responsePath, ok := cfg["response_path"].(string); ok {
 		r.responseJSONField = responsePath
-		r.responseJSON = true
+		if responseJSONExplicit && !r.responseJSON {
+			slog.Warn("'response_path' would enable JSON parsing, but 'response_json' is explicitly false; respecting 'response_json: false'",
+				"response_path", responsePath)
+		} else {
+			r.responseJSON = true
+		}
 	}
 
 	// Validate JSON response configuration

--- a/internal/generators/rest/rest_test.go
+++ b/internal/generators/rest/rest_test.go
@@ -570,6 +570,155 @@ func TestRestGenerator_Generate_JSONEscapeInput(t *testing.T) {
 	}
 }
 
+// TestNewRest_EndpointAlias verifies that "endpoint" works as an alias for "uri".
+func TestNewRest_EndpointAlias(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	g, err := NewRest(registry.Config{
+		"endpoint": server.URL,
+	})
+	require.NoError(t, err, "NewRest with 'endpoint' key should succeed")
+
+	conv := attempt.NewConversation()
+	conv.AddPrompt("hello")
+
+	responses, err := g.Generate(context.Background(), conv, 1)
+	require.NoError(t, err)
+	assert.Len(t, responses, 1)
+	assert.Equal(t, "ok", responses[0].Content)
+}
+
+// TestNewRest_BodyAlias verifies that "body" works as an alias for "req_template".
+func TestNewRest_BodyAlias(t *testing.T) {
+	var received string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf, _ := io.ReadAll(r.Body)
+		received = string(buf)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	g, err := NewRest(registry.Config{
+		"uri":  server.URL,
+		"body": `{"input":"$INPUT"}`,
+	})
+	require.NoError(t, err, "NewRest with 'body' key should succeed")
+
+	conv := attempt.NewConversation()
+	conv.AddPrompt("test-input")
+
+	_, err = g.Generate(context.Background(), conv, 1)
+	require.NoError(t, err)
+	assert.Equal(t, `{"input":"test-input"}`, received)
+}
+
+// TestNewRest_ResponsePathAlias verifies that "response_path" works as an alias
+// for "response_json_field" and also implicitly enables JSON parsing.
+func TestNewRest_ResponsePathAlias(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"answer":"hello from path"}`)
+	}))
+	defer server.Close()
+
+	g, err := NewRest(registry.Config{
+		"uri":           server.URL,
+		"response_path": "answer",
+	})
+	require.NoError(t, err, "NewRest with 'response_path' key should succeed")
+
+	conv := attempt.NewConversation()
+	conv.AddPrompt("ping")
+
+	responses, err := g.Generate(context.Background(), conv, 1)
+	require.NoError(t, err)
+	assert.Len(t, responses, 1)
+	assert.Equal(t, "hello from path", responses[0].Content)
+}
+
+// TestNewRest_URITakesPrecedenceOverEndpoint verifies that when both "uri" and
+// "endpoint" are present, "uri" wins.
+func TestNewRest_URITakesPrecedenceOverEndpoint(t *testing.T) {
+	uriServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("from-uri"))
+	}))
+	defer uriServer.Close()
+
+	endpointServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("from-endpoint"))
+	}))
+	defer endpointServer.Close()
+
+	g, err := NewRest(registry.Config{
+		"uri":      uriServer.URL,
+		"endpoint": endpointServer.URL,
+	})
+	require.NoError(t, err)
+
+	conv := attempt.NewConversation()
+	conv.AddPrompt("test")
+
+	responses, err := g.Generate(context.Background(), conv, 1)
+	require.NoError(t, err)
+	assert.Len(t, responses, 1)
+	assert.Equal(t, "from-uri", responses[0].Content, "uri should take precedence over endpoint")
+}
+
+// TestNewRest_ReqTemplateTakesPrecedenceOverBody verifies that when both
+// "req_template" and "body" are present, "req_template" wins.
+func TestNewRest_ReqTemplateTakesPrecedenceOverBody(t *testing.T) {
+	var received string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf, _ := io.ReadAll(r.Body)
+		received = string(buf)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	g, err := NewRest(registry.Config{
+		"uri":          server.URL,
+		"req_template": `{"from":"req_template"}`,
+		"body":         `{"from":"body"}`,
+	})
+	require.NoError(t, err)
+
+	conv := attempt.NewConversation()
+	conv.AddPrompt("x")
+
+	_, err = g.Generate(context.Background(), conv, 1)
+	require.NoError(t, err)
+	assert.Equal(t, `{"from":"req_template"}`, received, "req_template should take precedence over body")
+}
+
+// TestNewRest_ResponseJSONFieldTakesPrecedenceOverResponsePath verifies that
+// when both "response_json_field" and "response_path" are present, "response_json_field" wins.
+func TestNewRest_ResponseJSONFieldTakesPrecedenceOverResponsePath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"canonical":"from-json-field","alias":"from-path"}`)
+	}))
+	defer server.Close()
+
+	g, err := NewRest(registry.Config{
+		"uri":                 server.URL,
+		"response_json":       true,
+		"response_json_field": "canonical",
+		"response_path":       "alias",
+	})
+	require.NoError(t, err)
+
+	conv := attempt.NewConversation()
+	conv.AddPrompt("ping")
+
+	responses, err := g.Generate(context.Background(), conv, 1)
+	require.NoError(t, err)
+	assert.Len(t, responses, 1)
+	assert.Equal(t, "from-json-field", responses[0].Content, "response_json_field should take precedence over response_path")
+}
+
 func TestRestGenerator_Generate_GETMethod(t *testing.T) {
 	var receivedParams string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/generators/rest/rest_test.go
+++ b/internal/generators/rest/rest_test.go
@@ -719,6 +719,33 @@ func TestNewRest_ResponseJSONFieldTakesPrecedenceOverResponsePath(t *testing.T) 
 	assert.Equal(t, "from-json-field", responses[0].Content, "response_json_field should take precedence over response_path")
 }
 
+// TestNewRest_ResponsePathRespectsExplicitResponseJSONFalse verifies that when
+// "response_path" is used alongside an explicit "response_json": false, the
+// explicit false is respected (response_json stays false).
+func TestNewRest_ResponsePathRespectsExplicitResponseJSONFalse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"answer":"raw json body"}`))
+	}))
+	defer server.Close()
+
+	g, err := NewRest(registry.Config{
+		"uri":           server.URL,
+		"response_json": false,
+		"response_path": "answer",
+	})
+	require.NoError(t, err)
+
+	conv := attempt.NewConversation()
+	conv.AddPrompt("ping")
+
+	responses, err := g.Generate(context.Background(), conv, 1)
+	require.NoError(t, err)
+	assert.Len(t, responses, 1)
+	// Because response_json is explicitly false, the raw body should be returned
+	assert.Equal(t, `{"answer":"raw json body"}`, responses[0].Content,
+		"explicit response_json: false should prevent JSON field extraction even with response_path alias")
+}
+
 func TestRestGenerator_Generate_GETMethod(t *testing.T) {
 	var receivedParams string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- REST generator now accepts Guard's `GeneratorConfig` field names (`endpoint`, `body`, `response_path`) as aliases for its native keys (`uri`, `req_template`, `response_json_field`)
- Native keys always take precedence when both are present
- Aliases added in both `NewRest()` and `ConfigFromMap()` code paths

## Motivation
Guard's `buildTargetGenerator()` passes config fields using `GeneratorConfig` struct keys, but the rest generator expected its own native key names. This caused rest generator initialization to fail with `"rest generator requires 'uri' configuration"` when invoked via Guard. The openai generator was unaffected since it handles its own config parsing — this only impacts endpoints that require the rest generator (e.g., non-Bearer auth like cookies or custom headers).

## Test plan
- [x] 12 new tests: alias acceptance + precedence for all 3 keys in both `NewRest()` and `ConfigFromMap()`
- [x] Full test suite passes with race detector (`go test ./... -race`)