### PR TITLE
ci: fix workflow action versions (unblock startup_failure)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: 'go.mod'
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: latest
           args: --timeout=5m
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -58,10 +58,10 @@ jobs:
         goarch: [amd64, arm64]
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: 'go.mod'
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,24 +10,22 @@ on:
 permissions:
   contents: read
 
-env:
-  GO_VERSION: '1.25.3'
-
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
+          cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
           args: --timeout=5m
@@ -37,12 +35,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
+          cache: true
 
       - name: Download dependencies
         run: go mod download
@@ -59,12 +58,13 @@ jobs:
         goarch: [amd64, arm64]
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
+          cache: true
 
       - name: Build
         env:


### PR DESCRIPTION
## Summary

CI has been returning `startup_failure` in 0 seconds on every run since 2026-03-14. The root cause is that `ci.yml` was pinned to hallucinated action versions that GitHub's runner infrastructure cannot resolve at startup:

- `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2` — v6 does not exist; SHA is fabricated
- `actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0` — v6 does not exist; SHA is fabricated
- `golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0` — SHA may not resolve

## Fix

Replaced all action references with known-working pins sourced from sibling capabilities (titus, hadrian, florian):

| Action | Old (broken) | New (working) |
|--------|-------------|---------------|
| `actions/checkout` | `@de0fac2e...` v6.0.2 | `@11bd71901bbe5b1630ceea73d27597364c9af683` v4.2.2 |
| `actions/setup-go` | `@4b73464b...` v6.3.0 | `@f111f3307d8850f501ac008e886eec1fd1932a34` v5.3.0 |
| `golangci/golangci-lint-action` | `@1e7e51e7...` v9.2.0 | `@v9` |

Additional changes:
- `actions/setup-go` `with:` block updated to use `go-version-file: 'go.mod'` + `cache: true` (matches titus pattern)
- Removed unused top-level `env: GO_VERSION: '1.25.3'` block

No other changes — triggers, permissions, test/build steps, and matrix are identical.

## Test Plan

This PR itself tests the fix. If the CI workflow starts running (status goes from nothing → `pending` → `in_progress`) rather than immediately returning `startup_failure`, the fix is confirmed working.

- [ ] CI lint job starts and completes
- [ ] CI test job starts and completes
- [ ] CI build matrix (6 platform combinations) starts and completes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)