### PR TITLE
Add Claude PR Assistant workflow

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,16 @@
+name: Claude PR Assistant
+
+on:
+  pull_request:
+    types: [synchronize, opened]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude-code-action:
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-code.yml` wiring augustus into the centralized `praetorian-inc/public-workflows/.github/workflows/claude-code.yml@main` reusable workflow
- Matches the existing setup in titus — byte-for-byte identical
- Enables the Claude PR Assistant on PR open/sync and review comments

## Test plan
- [ ] Workflow appears in the Actions tab after merge
- [ ] `@claude` mentions on a follow-up PR trigger the assistant

🤖 Generated with [Claude Code](https://claude.com/claude-code)