### PR TITLE
ci: add centralized go-security.yml workflow (gosec + govulncheck)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,21 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'  # Mondays 06:00 UTC — weekly baseline
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  security:
+    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@d805693c16ea002e098e5520592959a8e98e12ac  # v1.1.0
+    permissions:
+      contents: read
+      security-events: write
+    secrets: inherit


### PR DESCRIPTION
Adds `.github/workflows/security.yml` calling centralized `praetorian-inc/public-workflows/go-security.yml@v1.1.0` (SHA `d805693c16ea002e098e5520592959a8e98e12ac`). Runs gosec (SAST) and govulncheck (Go vulndb) on push, PR, and weekly Monday schedule. SARIF findings published to GitHub Security tab.

Part of ENG-3079 supply-chain hardening rollout. Security is separate from `go-ci.yml` so callers only grant `security-events: write` when needed; scans can run on a different cadence; a broken security tool doesn't block builds.

See https://github.com/praetorian-inc/public-workflows/pull/9 for the reusable workflow definition and rationale.

## Test plan
- [ ] gosec job completes (observe-only)
- [ ] govulncheck job completes
- [ ] SARIF findings appear in Security tab after merge