### PR TITLE
fix(ci): bump go-security.yml pin v1.1.0 → v1.1.2

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   security:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@d805693c16ea002e098e5520592959a8e98e12ac  # v1.1.0
+    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@a2b8d84dbc6aa0136dabf4ce5dda0fe28b6bf407  # v1.1.2
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
Follow-up fix for the go-security.yml rollout.

The initial PR (which added `.github/workflows/security.yml`) merged while pinned to `go-security.yml@v1.1.0`, which has two issues that were fixed after the merge:
- `securego/gosec` Docker action is not on the praetorian-inc org allowlist, causing `startup_failure` on every run → fixed in [v1.1.1](https://github.com/praetorian-inc/public-workflows/pull/10) by switching to pinned `go install`
- govulncheck exit-3 truncated the SARIF output, breaking upload → fixed in [v1.1.2](https://github.com/praetorian-inc/public-workflows/pull/14) by robust SARIF handling. Same release also bumps codeql-action/upload-sarif to v4 ([#15](https://github.com/praetorian-inc/public-workflows/pull/15)) for Node 24.

This PR just updates the pin on main. No other changes.

Part of ENG-3079.