### PR TITLE
chore(ci): bump go-security.yml pin to v2.0.1

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   security:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@d805693c16ea002e098e5520592959a8e98e12ac  # v1.1.0
+    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@4900fbd3aaf1992181e2ebfb108c71fee8250c67  # v2.0.1
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
Picks up the govulncheck SARIF upload fix shipped in https://github.com/praetorian-inc/public-workflows/pull/14. Was failing with `Invalid SARIF. JSON syntax error: Unexpected end of JSON input` on every run when govulncheck found vulnerabilities (exit 3) under the default `bash -e` shell. Fix is cumulative; no other behavior change for this consumer.

Related: ENG-3079 CI/CD supply-chain hardening.