### PR TITLE
chore(ci): sweep public-workflows pins to v2.0.10 (135c500)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   ci:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@7867fcf335716be84f807cf3d9c1eed44eb5d7c1  # v1.0.1
+    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@135c50049eeef6e664bd7ea4aacaa33118083e30  # v2.0.10
     permissions:
       contents: read
     with:

--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   notify:
-    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@faa2e42989736cf9b3f47e5377dd5f2e0327517f  # v2.0.2
+    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@135c50049eeef6e664bd7ea4aacaa33118083e30  # v2.0.10
     secrets: inherit


### PR DESCRIPTION
Bump `praetorian-inc/public-workflows/.github/workflows/*` pins to `135c50049eeef6e664bd7ea4aacaa33118083e30` (v2.0.10).

Files bumped:
- ` .github/workflows/ci.yml .github/workflows/external-contribution.yml`

Part of the public-workflows drift cleanup. See [ENG-3079](https://linear.app/praetorianlabs/issue/ENG-3079).