### PR TITLE
fix(ci): explicit permissions + secrets map in external-contribution.yml

### DIFF
--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -6,7 +6,30 @@ on:
   pull_request_target:
     types: [opened, assigned, closed]
 
+# Permissions are declared explicitly at the caller. Reusable workflows
+# cannot elevate GITHUB_TOKEN beyond what the caller grants, so if this
+# block is omitted the notify job falls back to org/repo default token
+# permissions — which may be read-only, causing Linear/GitHub comment
+# writes to fail with "Resource not accessible by integration".
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   notify:
     uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@135c50049eeef6e664bd7ea4aacaa33118083e30  # v2.0.10
-    secrets: inherit
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    secrets:
+      EXTERNAL_CONTRIB_APP_ID: ${{ secrets.EXTERNAL_CONTRIB_APP_ID }}
+      EXTERNAL_CONTRIB_APP_PRIVATE_KEY: ${{ secrets.EXTERNAL_CONTRIB_APP_PRIVATE_KEY }}
+      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
+      SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+      LINEAR_ASSIGNEE_ID: ${{ secrets.LINEAR_ASSIGNEE_ID }}
+      LINEAR_PARENT_ISSUE_ID: ${{ secrets.LINEAR_PARENT_ISSUE_ID }}
+      LINEAR_PROJECT_ID: ${{ secrets.LINEAR_PROJECT_ID }}


### PR DESCRIPTION
Fix augustus's external-contribution workflow `startup_failure` by switching from `secrets: inherit` (without a permissions block) to the explicit permissions + secrets-map pattern used by the other 16 capability repos.

**Root cause:** The reusable at `external-contrib-notify.yml@v2.0.10` declares required secrets and requires caller-level permissions. With `secrets: inherit` alone and no `permissions:` block, GitHub's parser bails out before jobs can run.

**Reference working pattern:** aurelian / brutus / caligula / etc.

Part of the public-workflows drift cleanup. See [ENG-3079](https://linear.app/praetorianlabs/issue/ENG-3079).