### PR TITLE
fix(ci): remove unsupported golangci-lint-only-new-issues input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,4 @@ jobs:
     with:
       build-cmd-path: ./cmd/augustus
       build-binary-name: augustus
-      golangci-lint-only-new-issues: true
     secrets: inherit


### PR DESCRIPTION
`go-ci.yml@v2.0.11` does not expose a `golangci-lint-only-new-issues` input. Passing it causes a CI startup_failure ("workflow file issue") before any job can run. See [run 24641583792](https://github.com/praetorian-inc/augustus/actions/runs/24641583792).

## Fix

Drop the invalid input from the caller.

## Follow-up (optional)

If only-new-issues behavior is actually wanted, file a feature PR upstream on [praetorian-inc/public-workflows](https://github.com/praetorian-inc/public-workflows) to add a `golangci-lint-only-new-issues` pass-through input, then bump this caller once it lands. Not in scope for this PR.