### PR TITLE
fix(ci): pin codex-code.yml to public-workflows v2.1.2

### DIFF
--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   codex-review:
-    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@5fe31f5bfb48b12d7b05201f2d1b1bf006b6a3e5  # v2.1.1 (hardened sandbox)
+    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@4b6e7658373571aa4b4d1a57ee14ad183353ce49  # v2.1.2 (private repo pre-fetch fix)
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- Bumps reusable Codex PR reviewer from `v2.1.1` to `v2.1.2`
- Fixes `fatal: could not read Username` failure on private repos (pre-fetch step now uses one-shot `git -c` credential)
- Upstream fix: https://github.com/praetorian-inc/public-workflows/pull/36

## Test plan
- [ ] Verify codex-review job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)