### PR TITLE
chore: bump external-contrib-notify to v2.1.0

### DIFF
--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   notify:
-    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@7c1302bdef0a72e7f5743738baa45272c8e1f8d7  # v2.1.0  # v2.0.13
+    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@7c1302bdef0a72e7f5743738baa45272c8e1f8d7  # v2.1.0
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -11,6 +11,9 @@ on:
 # block is omitted the notify job falls back to org/repo default token
 # permissions — which may be read-only, causing Linear/GitHub comment
 # writes to fail with "Resource not accessible by integration".
+concurrency:
+  group: external-contribution-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
   issues: write
@@ -18,7 +21,7 @@ permissions:
 
 jobs:
   notify:
-    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@3dcf34cfbe5e1332d490d28ed1bd119cd86cf81b  # v2.0.13
+    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@7c1302bdef0a72e7f5743738baa45272c8e1f8d7  # v2.1.0  # v2.0.13
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
## Summary

- Bumps `external-contrib-notify.yml` SHA from `3dcf34cf...` (v2.0.13) to `7c1302bdef0a72e7f5743738baa45272c8e1f8d7` (v2.1.0)
- Adds `concurrency:` block to prevent duplicate workflow runs on rapid pushes/reopens

## Test plan

- [ ] Verify the workflow file contains the new SHA `7c1302bd`
- [ ] Verify `concurrency:` block is present before `permissions:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)