### PR TITLE
fix(rest): handle plain JSON string values in SSE default parser

### DIFF
--- a/internal/generators/rest/rest.go
+++ b/internal/generators/rest/rest.go
@@ -698,10 +698,14 @@ func (r *Rest) parseSSEDefault(body []byte) string {
 			continue
 		}
 
-		// Try to parse as JSON
+		// Try to parse as JSON object
 		var data map[string]any
 		if err := json.Unmarshal([]byte(jsonStr), &data); err != nil {
-			// Not valid JSON, skip
+			// Not a JSON object; try as a plain JSON string (e.g., data: "Hello world")
+			var strData string
+			if err := json.Unmarshal([]byte(jsonStr), &strData); err == nil && strData != "" {
+				textParts = append(textParts, strData)
+			}
 			continue
 		}
 

--- a/internal/generators/rest/rest_test.go
+++ b/internal/generators/rest/rest_test.go
@@ -1759,6 +1759,75 @@ func TestRestGenerator_SSEConfigurable_MissingTextField(t *testing.T) {
 	}
 }
 
+func TestRestGenerator_SSEDefault_PlainJSONStrings(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: started\n"))
+		_, _ = w.Write([]byte("data: \"Hello \"\n\n"))
+		_, _ = w.Write([]byte("event: chunk\n"))
+		_, _ = w.Write([]byte("data: \"World!\"\n\n"))
+	}))
+	defer server.Close()
+
+	g, err := NewRest(registry.Config{
+		"uri": server.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewRest() error = %v", err)
+	}
+
+	conv := attempt.NewConversation()
+	conv.AddPrompt("test")
+
+	responses, err := g.Generate(context.Background(), conv, 1)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	if len(responses) != 1 {
+		t.Fatalf("Generate() returned %d responses, want 1", len(responses))
+	}
+
+	expected := "Hello World!"
+	if responses[0].Content != expected {
+		t.Errorf("Generate() content = %q, want %q", responses[0].Content, expected)
+	}
+}
+
+func TestRestGenerator_SSEDefault_MixedObjectsAndStrings(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"delta\":{\"text\":\"From object\"}}\n\n"))
+		_, _ = w.Write([]byte("data: \"From string\"\n\n"))
+		_, _ = w.Write([]byte("data: {\"text\":\"Direct\"}\n\n"))
+	}))
+	defer server.Close()
+
+	g, err := NewRest(registry.Config{
+		"uri": server.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewRest() error = %v", err)
+	}
+
+	conv := attempt.NewConversation()
+	conv.AddPrompt("test")
+
+	responses, err := g.Generate(context.Background(), conv, 1)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	if len(responses) != 1 {
+		t.Fatalf("Generate() returned %d responses, want 1", len(responses))
+	}
+
+	expected := "From objectFrom stringDirect"
+	if responses[0].Content != expected {
+		t.Errorf("Generate() content = %q, want %q", responses[0].Content, expected)
+	}
+}
+
 func TestRestGeneratorHookVarSubstitution(t *testing.T) {
 	// Create a test server that echoes the request body back
 	var receivedBody string


### PR DESCRIPTION
## Summary

- Fix default SSE parser in `rest.Rest` generator to handle plain JSON string data values
- Previously, only JSON object data values were parsed; plain strings fell through to raw body fallback
- This caused downstream detectors to evaluate raw SSE markup instead of response text, producing false positives

## Problem

Some LLM endpoints return SSE streams where data lines contain plain JSON strings rather than JSON objects:

```
event: chunk
data: "Hello "

event: chunk  
data: "World!"
```

The default parser only attempts `json.Unmarshal` into `map[string]any`, which fails for quoted strings. The fallback returns the entire raw SSE body including event metadata, which confuses detectors.

Note: `parseSSEConfigurable` already handles this correctly via `var any` unmarshal. This fix brings `parseSSEDefault` to parity.

## Fix

After the object unmarshal fails in `parseSSEDefault`, attempt to unmarshal as a plain `string`. Purely additive:

- Existing JSON object parsing is unaffected
- `parseSSEConfigurable` is unchanged (already works)
- Raw body fallback still handles non-JSON data lines
- No new configuration required

## Test plan

- [x] `TestRestGenerator_SSEDefault_PlainJSONStrings` -- plain JSON string data values
- [x] `TestRestGenerator_SSEDefault_MixedObjectsAndStrings` -- mixed object and string formats
- [x] All existing SSE tests pass unchanged (14 existing + 2 new = 16 total)
- [x] `go test ./internal/generators/rest/ -v -run SSE` -- 16/16 pass