### PR TITLE
fix(harness): prefer probe's primary detector over highest-scoring generic detector

### DIFF
--- a/pkg/harnesses/detection.go
+++ b/pkg/harnesses/detection.go
@@ -102,9 +102,32 @@ func ApplyDetectors(
 		}
 	}
 
-	// Set primary detector to one with highest score
-	// If no detector had scores, use first detector
-	if primaryDetector != "" {
+	// Determine the primary detector for this attempt.
+	//
+	// Probes set a.Detector to their recommended detector during attempt
+	// creation (e.g., toolhijack.ToolSelection for toolhijack probes).
+	// When the probe's detector was run and produced results, prefer it
+	// over the highest-scoring detector. This prevents unrelated generic
+	// detectors (e.g., goodside.Glitch) from overriding probe-specific
+	// results when multiple detectors are active (--all or --probes-glob).
+	//
+	// Fallback order:
+	// 1. Probe's own detector (if set and has results)
+	// 2. Highest-scoring detector across all detectors
+	// 3. First detector that ran
+	probeDetector := a.Detector
+	if probeDetector != "" {
+		if scores, ok := a.DetectorResults[probeDetector]; ok && len(scores) > 0 {
+			// Probe's detector ran and produced results; keep it
+			a.Scores = scores
+		} else if primaryDetector != "" {
+			a.Detector = primaryDetector
+			a.Scores = primaryScores
+		} else if firstDetector != "" {
+			a.Detector = firstDetector
+			a.Scores = firstScores
+		}
+	} else if primaryDetector != "" {
 		a.Detector = primaryDetector
 		a.Scores = primaryScores
 	} else if firstDetector != "" {

--- a/pkg/harnesses/detection_test.go
+++ b/pkg/harnesses/detection_test.go
@@ -221,3 +221,65 @@ func TestApplyDetectors_PrePopulatedMixedWithExternal(t *testing.T) {
 	// External detector results should also be stored
 	assert.Equal(t, []float64{0.9}, a.DetectorResults["other.Detector"])
 }
+
+func TestApplyDetectors_ProbeDetectorTakesPriority(t *testing.T) {
+	ctx := context.Background()
+	a := attempt.New("test prompt")
+
+	// Simulate a probe that set its primary detector on the attempt
+	a.Detector = "probe.SpecificDetector"
+
+	detectorList := []detectors.Detector{
+		&mockDetector{name: "probe.SpecificDetector", scores: []float64{0.0}}, // Probe's detector says safe
+		&mockDetector{name: "generic.Glitch", scores: []float64{1.0}},         // Generic detector says vulnerable
+	}
+
+	err := ApplyDetectors(ctx, a, detectorList, SkipOnError)
+	require.NoError(t, err)
+
+	// Probe's own detector should win even though generic scored higher
+	assert.Equal(t, "probe.SpecificDetector", a.Detector)
+	assert.Equal(t, []float64{0.0}, a.Scores)
+
+	// Both detector results should still be stored
+	assert.Len(t, a.DetectorResults, 2)
+	assert.Equal(t, []float64{0.0}, a.DetectorResults["probe.SpecificDetector"])
+	assert.Equal(t, []float64{1.0}, a.DetectorResults["generic.Glitch"])
+}
+
+func TestApplyDetectors_ProbeDetectorNotInList_FallsBack(t *testing.T) {
+	ctx := context.Background()
+	a := attempt.New("test prompt")
+
+	// Probe set a detector that isn't in the detector list
+	a.Detector = "missing.Detector"
+
+	detectorList := []detectors.Detector{
+		&mockDetector{name: "available.Detector", scores: []float64{0.7}},
+	}
+
+	err := ApplyDetectors(ctx, a, detectorList, SkipOnError)
+	require.NoError(t, err)
+
+	// Should fall back to highest-scoring available detector
+	assert.Equal(t, "available.Detector", a.Detector)
+	assert.Equal(t, []float64{0.7}, a.Scores)
+}
+
+func TestApplyDetectors_NoProbeDetector_HighestScoreWins(t *testing.T) {
+	ctx := context.Background()
+	a := attempt.New("test prompt")
+
+	// No probe detector set (a.Detector is empty)
+	detectorList := []detectors.Detector{
+		&mockDetector{name: "low.Detector", scores: []float64{0.2}},
+		&mockDetector{name: "high.Detector", scores: []float64{0.8}},
+	}
+
+	err := ApplyDetectors(ctx, a, detectorList, SkipOnError)
+	require.NoError(t, err)
+
+	// Should behave like before: highest score wins
+	assert.Equal(t, "high.Detector", a.Detector)
+	assert.Equal(t, []float64{0.8}, a.Scores)
+}


### PR DESCRIPTION
## Summary

- Fix false positives when running multiple probes with `--all` or `--probes-glob`
- Probe-specific detectors are now preferred over unrelated generic detectors that happen to score higher
- Three new test cases added; all 12 detection tests pass

## Problem

When multiple detectors are active, `ApplyDetectors` runs every detector against every probe attempt and selects the **highest-scoring** detector as primary. This causes false positives when a generic detector (e.g., `goodside.Glitch`) produces a high score on criteria unrelated to what the probe is actually testing.

Example: A `toolhijack.SemanticLure` probe correctly identifies no vulnerability via its `toolhijack.ToolSelection` detector (score 0.0), but `goodside.Glitch` scores 1.0 on unrelated token patterns in the response. The highest-score logic selects `goodside.Glitch` as primary, marking the attempt as VULN despite the probe's own detector confirming it's safe.

## Root Cause

Probes already set `a.Detector` to their recommended detector during attempt creation (via `RunPrompts` or direct assignment). However, `ApplyDetectors` unconditionally overwrites this value with whichever detector scores highest, ignoring the probe's recommendation.

## Fix

Respect the probe's pre-set `a.Detector` value. If the probe's detector was run and produced results, use those results as primary. Fall back to highest-scoring only when:
- The probe didn't set a detector (`a.Detector` is empty)
- The probe's detector wasn't in the active detector list

Fallback order:
1. Probe's own detector (if set and has results)
2. Highest-scoring detector across all detectors
3. First detector that ran

This is backward-compatible: probes that don't set `a.Detector` (empty string) get the existing highest-score behavior unchanged.

## Test plan

- [x] `TestApplyDetectors_ProbeDetectorTakesPriority` -- probe's detector wins over higher-scoring generic
- [x] `TestApplyDetectors_ProbeDetectorNotInList_FallsBack` -- graceful fallback when probe's detector isn't available
- [x] `TestApplyDetectors_NoProbeDetector_HighestScoreWins` -- backward compatibility for probes without a detector set
- [x] All 9 existing detection tests pass unchanged
- [x] `go test ./pkg/harnesses/ -v -run Detect` -- 12/12 pass