### PR TITLE
feat: add changelog grouping and supply chain hooks to goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,10 @@
 version: 2
 
+before:
+  hooks:
+    - go mod tidy -diff
+    - go mod verify
+
 builds:
   - main: ./cmd/augustus
     binary: augustus
@@ -22,7 +27,20 @@ checksum:
   name_template: checksums.txt
 
 changelog:
+  use: github
   sort: asc
+  groups:
+    - title: "Breaking Changes"
+      regexp: '^.*?[a-zA-Z]+(\([^)]+\))?!:.+$'
+      order: 0
+    - title: "Features"
+      regexp: '^.*?feat(\([^)]+\))?!?:.+$'
+      order: 1
+    - title: "Bug Fixes"
+      regexp: '^.*?fix(\([^)]+\))?!?:.+$'
+      order: 2
+    - title: "Other Changes"
+      order: 999
   filters:
     exclude:
       - "^docs:"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,9 +43,9 @@ changelog:
       order: 999
   filters:
     exclude:
-      - "^docs:"
-      - "^test:"
-      - "^chore:"
+      - '^.*?docs(\([^)]+\))?!?:.+$'
+      - '^.*?test(\([^)]+\))?!?:.+$'
+      - '^.*?chore(\([^)]+\))?!?:.+$'
 
 sboms:
   - artifacts: archive


### PR DESCRIPTION
## Summary

Improves the GoReleaser config with supply chain hooks and structured changelogs.

- **Before hooks**: `go mod tidy -diff` + `go mod verify` run before every release build. `tidy -diff` fails fast if modules are dirty (never modifies files mid-release). `verify` validates cached dependency checksums against go.sum.
- **Changelog grouping**: Release notes organized by conventional commit type (Breaking Changes, Features, Bug Fixes, Other) using the GitHub API for PR links and author handles. Scope regex supports hyphens. Breaking regex handles GoReleaser's SHA-prefixed entry format.

Incorporates 3 rounds of multi-model review feedback (Claude, Gemini, Codex).

Supersedes #133.

## Test plan

- [x] `goreleaser check` passes
- [ ] Verify next release produces grouped changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)