### PR TITLE
chore(ci): bump codex-code pin — fixes sudo failure + CVE-2025-32955 container lockdown

### DIFF
--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   codex-review:
-    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@7c1302bdef0a72e7f5743738baa45272c8e1f8d7  # v2.1.0  # v2.1.2 (private repo pre-fetch fix)
+    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@168b9190943858d15c9431072c96059e8d2e0e8d  # post-PR80: codex sudo + CVE-2025-32955 container fix (was v2.1.0)
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Bumps the Codex PR Review reusable pin from `7c1302b` (v2.1.0) to `168b919` (public-workflows main after PR #80).

Fixes two issues in the shared codex-review workflow:
1. **Sudo failure** — v2.1.0 disabled sudo via Harden-Runner, but openai/codex-action needs sudo to lock its proxy server-info file then drop sudo itself, so every real codex review failed with `sudo: a password is required`.
2. **CVE-2025-32955** — the fix re-enables sudo but adds a step that stops Docker/containerd before Codex runs, preserving container-escape protection (drop-sudo alone doesn't remove docker-group access).

Verified end-to-end on public-workflows (PRs #81/#82). `.github`-only change → codex preflight-skips on this PR; the fix is exercised by the next real code PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)