### PR TITLE
test: VERIFY codex fix on augustus (throwaway — do not merge)

### DIFF
--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   codex-review:
-    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@7c1302bdef0a72e7f5743738baa45272c8e1f8d7  # v2.1.0  # v2.1.2 (private repo pre-fetch fix)
+    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@168b9190943858d15c9431072c96059e8d2e0e8d  # post-PR80: codex sudo + CVE-2025-32955 container fix (was v2.1.0)
     permissions:
       contents: read
       pull-requests: write

--- a/verify-codex-fix.json
+++ b/verify-codex-fix.json
@@ -1,0 +1,1 @@
+{"purpose":"throwaway: force has_code=true to verify codex runs against the fixed reusable; PR closed after verification"}


### PR DESCRIPTION
Throwaway: bumps codex pin to 168b919 (post-#80) + dummy file so codex actually runs on the augustus caller. Confirms sudo fix + container lockdown work here. Closed after verification.