### PR TITLE
feat(release): pin go-release v2.4.0 + push tags via version-bumper App

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,15 @@ permissions:
 
 jobs:
   release:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-release.yml@f2c1dd0dc514e3eef1da72d96810fda16e7f4296  # v3.0.0
+    uses: praetorian-inc/public-workflows/.github/workflows/go-release.yml@f7fb4810ccab4ab589499b632fb61983124ece79  # v2.4.0
     permissions:
       contents: write
       id-token: write
       attestations: write
     with:
       release-mode: auto-tag-from-main
+    # Push the auto-tag as the praetorian-ci-version-bumper App so it can bypass
+    # the org "Protected Version Tags" ruleset (creation-only bypass).
+    secrets:
+      VERSION_BUMPER_APP_ID: ${{ secrets.VERSION_BUMPER_APP_ID }}
+      VERSION_BUMPER_PRIVATE_KEY: ${{ secrets.VERSION_BUMPER_PRIVATE_KEY }}


### PR DESCRIPTION
## What

- Bumps the `go-release.yml` pin from `f2c1dd0` (2026-05-26, pre-fixes, mislabeled `# v3.0.0`) → **`f7fb4810` # v2.4.0**.
- Passes `VERSION_BUMPER_APP_ID`/`VERSION_BUMPER_PRIVATE_KEY` through to go-release so the auto-tag-from-main tag is pushed as the **praetorian-ci-version-bumper** App.

## Why

augustus is **public** and uses `release-mode: auto-tag-from-main`, which creates `v*` tags on every merge to main. The org **Protected Version Tags** ruleset blocks `GITHUB_TOKEN` from creating those tags, so releases have been failing. The old pin also predates the auto-tag bug fixes:
- #83 — semver sort (picked v1.0.0 as 'latest')
- #84 — `git tag`/`push` arg fix (`--` swallowed `-m`/refspec)
- #86 — App-token support

The App is a **creation-only** bypass actor (org ruleset split: it can create tags but cannot delete/move them).

## Prerequisites (done)

- ✅ App installed on augustus *(pending your UI step)*
- ✅ Repo secrets `VERSION_BUMPER_*` set

## Verification after merge

Merge to main → `resolve-version` mints the App token → creates the next `v*` tag → goreleaser builds the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)