### PR TITLE
fix(release): grant packages: write (unblocks startup_failure)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     uses: praetorian-inc/public-workflows/.github/workflows/go-release.yml@f7fb4810ccab4ab589499b632fb61983124ece79  # v2.4.0
     permissions:
       contents: write
+      packages: write
       id-token: write
       attestations: write
     with:


### PR DESCRIPTION
## Root cause

augustus's `release.yml` has failed at **startup** on every run since it was added (pre-existing, not the App work):

```
Invalid workflow file: release.yml#L11 — nested job 'goreleaser' is requesting
'packages: write', but is only allowed 'packages: none'.
```

go-release.yml's `goreleaser` job statically declares `contents/packages/id-token/attestations: write` (it documents that callers must grant all of them, since reusable permissions can't be gated on inputs). The caller granted everything **except `packages: write`** → the workflow never compiled, so the auto-tag + App-token logic never ran.

## Fix

Add `packages: write` to the caller's `release` job permissions. (Unused unless `publish-container: true`, but required to satisfy the static contract.)

## After merge

The Release workflow will finally start → `resolve-version` mints the version-bumper App token → creates augustus's next `v*` tag (requires the App installed on augustus, which is the remaining manual step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)