### PR TITLE
build(release): emit SBOM + cosign signature (supply-chain hardening)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,3 +28,18 @@ changelog:
       - "^docs:"
       - "^test:"
       - "^chore:"
+
+sboms:
+  - artifacts: archive
+
+signs:
+  - cmd: cosign
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+    output: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,6 +32,12 @@ changelog:
 sboms:
   - artifacts: archive
 
+# cosign keyless OIDC signing of the checksums file. NOTE: these are the cosign
+# v2 sign-blob flags. The central go-release.yml SHA-pins cosign via
+# sigstore/cosign-installer@v3.8.2 (=> cosign v2.4.3, verified shipping .sig+.pem).
+# cosign v3 replaces --output-certificate/--output-signature with a single
+# --bundle=${signature} (.sigstore.json); migrate this stanza in lockstep IF/when
+# the central workflow bumps cosign to v3.
 signs:
   - cmd: cosign
     certificate: "${artifact}.pem"


### PR DESCRIPTION
## What

Backfills the **SBOM + cosign signing** blocks into this repo's `.goreleaser.yaml`, matching the proven julius config (PR praetorian-inc/julius#104).

```yaml
sboms:
  - artifacts: archive          # Syft SBOM per archive
signs:
  - cmd: cosign                 # cosign keyless OIDC signing of checksums.txt
    certificate: "${artifact}.pem"
    args: [sign-blob, --output-certificate=${certificate}, --output-signature=${signature}, ${artifact}, --yes]
    artifacts: checksum
    output: true
```

## Why

The central `go-release.yml` defaults `enable-sbom`/`enable-sign` true and installs Syft+cosign, but GoReleaser only emits these artifacts when the local config declares `sboms:`/`signs:`. Without them the supply-chain hardening was silently skipped — this repo's last release shipped no `.sbom`/`.sig`/`.pem`.

## Proven

julius `v1.2.1` (identical blocks) just shipped `checksums.txt.sig` + `checksums.txt.pem` + per-archive `*.sbom.json`. `goreleaser check` validated here too. Prereqs already satisfied by the workflow (Syft+cosign installed, `id-token: write` granted; cosign v2 keyless needs no COSIGN_EXPERIMENTAL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)