### PR TITLE
ci(release): cosign v3 + --bundle signing (pin go-release v2.5.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   release:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-release.yml@f7fb4810ccab4ab589499b632fb61983124ece79  # v2.4.0
+    uses: praetorian-inc/public-workflows/.github/workflows/go-release.yml@9a72aee6f0e4cbf4bc0c9ccbd9160f6664e3549e  # v2.5.0
     permissions:
       contents: write
       packages: write

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,3 +28,21 @@ changelog:
       - "^docs:"
       - "^test:"
       - "^chore:"
+
+sboms:
+  - artifacts: archive
+
+# cosign keyless OIDC signing of checksums.txt — cosign v3 modern Sigstore
+# .sigstore.json bundle. The central go-release.yml installs cosign v3 via
+# cosign-installer v4.1.2; sign-blob --bundle is the v3 form (v2's
+# --output-certificate/--output-signature were removed in cosign v3).
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sigstore.json"
+    args:
+      - sign-blob
+      - "--bundle=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+    output: true


### PR DESCRIPTION
## What
Combined cosign-v3 migration (pin + signing stanza move together):
- `release.yml`: bump go-release pin `v2.4.0` → **v2.5.0** (installs cosign v3.0.6 via cosign-installer v4.1.2)
- `.goreleaser.yaml`: `signs:` → cosign v3 `sign-blob --bundle` (`.sigstore.json`) + `sboms: artifacts: archive`

## Why combined
cosign v3 removed `--output-certificate`/`--output-signature`; the `--bundle` stanza needs cosign v3, which only v2.5.0 of go-release installs (via cosign-installer v4 — v3 installer can't install cosign v3). So pin + stanza must land together.

## Verify after merge
Release run green · `Generate app token` + `Run GoReleaser` success · assets include `checksums.txt.sigstore.json` · `cosign verify-blob --bundle checksums.txt.sigstore.json checksums.txt` passes · `go get` resolves new tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)