### PR TITLE
ci: bump Claude PR Assistant pin v2.1.0 -> v2.5.1

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@debcee1fd3a78e908b1f89d8f2bef0644c454cbc  # v2.1.0  # v2.0.12
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@ba1070edddbce95c1a5974fc72c24c60457145cf  # v2.5.1
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Bumps the central `claude-code.yml` reusable workflow pin from **v2.1.0** to **v2.5.1** (`ba1070e`).

## What changes
The only three differences in the central `claude-code.yml` across this range:
1. **`disable-sudo-and-containers: true`** on Harden-Runner — the CVE-2025-32955 hardening (closes the `disable-sudo` Docker-escape bypass).
2. Review model **`claude-opus-4-7` → `claude-opus-4-8`**.
3. **"Convert to PR review" step** — Claude's review lands in the Reviews tab alongside Codex/Gemini instead of as a loose issue comment.

## What does NOT change
The pinned `anthropics/claude-code-action` SHA is **`38ec876 # v1.0.101` at both v2.1.0 and v2.5.1** — identical. This bump is purely the wrapper hardening + UX.

Part of the capability CI convergence sweep — folds every capability repo onto the same hardened central wrapper version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)