### PR TITLE
fix(ci): re-pin titus-scan to real tag v2.6.0 + adopt verify-pins gate

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   scan:
-    uses: praetorian-inc/public-workflows/.github/workflows/titus-scan.yml@e2da966933b2c8f02a32540e7bd5812f93a056fb  # v2.2.1
+    uses: praetorian-inc/public-workflows/.github/workflows/titus-scan.yml@23254e12b026871dd9bbf2bad4ef6fee29910fb1  # v2.6.0
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/verify-pins.yml
+++ b/.github/workflows/verify-pins.yml
@@ -1,0 +1,16 @@
+name: Verify Pins
+# Fails CI if any first-party praetorian-inc/public-workflows `uses:` pin carries a
+# dishonest version comment (missing tag, nonexistent tag, or SHA != that tag).
+on:
+  pull_request:
+    paths: ['.github/workflows/**']
+  push:
+    branches: [main]
+    paths: ['.github/workflows/**']
+permissions:
+  contents: read
+jobs:
+  verify:
+    uses: praetorian-inc/public-workflows/.github/workflows/verify-pins.yml@23254e12b026871dd9bbf2bad4ef6fee29910fb1  # v2.6.0
+    permissions:
+      contents: read


### PR DESCRIPTION
Rebased onto current main (the original #146 conflicted with #145's claude-code bump). Re-pins titus-scan `# v2.2.1`(fictional)->`@23254e12b026 # v2.6.0` and adopts the verify-pins gate. claude-code is already honest (v2.5.1) via #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)