### PR TITLE
chore(ci): converge go-ci reusable to v2.6.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   ci:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@debcee1fd3a78e908b1f89d8f2bef0644c454cbc  # v2.2.0
+    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@9391f462483f0ca025fbbb57bfb0f9f9561e1b6a  # v2.6.6
     permissions:
       contents: read
     with:


### PR DESCRIPTION
Converges the `go-ci.yml` reusable pin to `9391f462483f0ca025fbbb57bfb0f9f9561e1b6a` (**v2.6.6**), the current canonical tag.

**Content delta vs the stale pin:** golangci-lint `v2.11.4 → v2.12.2`, preflight `pull-requests: read` permission (public-workflows#61), and script-injection hardening (github context → env vars). No change to `go test/build/vet`, golangci invocation, or job gating.

**Note:** the newer linter (v2.12.2) applies on the next *code* PR (this pin-only PR skips go-ci — no Go files changed). Pin `golangci-lint-version: v2.11.4` via the reusable input if you need to defer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)