### PR TITLE
chore(graphify): add code knowledge graph CI via shared reusable

### DIFF
--- a/.github/workflows/graphify-graph.yml
+++ b/.github/workflows/graphify-graph.yml
@@ -1,0 +1,38 @@
+name: graphify-graph
+# Builds the augustus code knowledge graph via the shared public-workflows reusable
+# and publishes graph.json as an artifact. graphify has no server — the graph is a
+# file that `graphify query` reads; engineers/agents pull the artifact instead of
+# each rebuilding it locally.
+#
+# Pull the latest graph:
+#   gh run download -R praetorian-inc/augustus -n augustus-graph -D graphify-out
+#
+# The pull_request trigger (scoped to this workflow + .graphifyignore) validates the
+# build on PRs that change the graphify config; push-to-main + weekly keep it fresh.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.graphifyignore'
+      - '.github/workflows/graphify-graph.yml'
+  pull_request:
+    paths:
+      - '.graphifyignore'
+      - '.github/workflows/graphify-graph.yml'
+  schedule:
+    - cron: '0 7 * * 1'   # Mondays 07:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  graph:
+    # Re-pin to the public-workflows release tag once PR #104 merges + tags.
+    uses: praetorian-inc/public-workflows/.github/workflows/graphify-graph.yml@b9d06c5aa3191ee6277148cdcdc998793d50f916  # PR #104 (re-pin to vX.Y.Z after merge)
+    permissions:
+      contents: read

--- a/.github/workflows/graphify-graph.yml
+++ b/.github/workflows/graphify-graph.yml
@@ -33,6 +33,6 @@ permissions:
 jobs:
   graph:
     # Re-pin to the public-workflows release tag once PR #104 merges + tags.
-    uses: praetorian-inc/public-workflows/.github/workflows/graphify-graph.yml@b9d06c5aa3191ee6277148cdcdc998793d50f916  # PR #104 (re-pin to vX.Y.Z after merge)
+    uses: praetorian-inc/public-workflows/.github/workflows/graphify-graph.yml@c81c12f1aae98b023e1aea25077c58a628857b6c  # v2.9.0
     permissions:
       contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ benchmark-results/
 .claude/.serena/
 .claude/.serena-warmup-status.json
 .claude/agent-memory/
+
+# graphify code knowledge graph (built locally / in CI; do not commit the 50k+ node graph)
+graphify-out/

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,39 @@
+# graphify: keyless code-only baseline.
+# Docs/papers/images require an LLM backend for semantic extraction; excluding them
+# keeps the graph buildable with no API key (AST-only `--no-cluster`) and matches
+# what the keyless per-commit hook (`graphify update`) maintains. To include docs
+# later, remove the relevant lines and rebuild with a backend (e.g. GEMINI_API_KEY).
+
+# Transient / generated noise (.json is treated as code by graphify)
+.claude/
+*-lock.json
+package-lock.json
+*.lock
+
+# Images
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.svg
+*.webp
+*.ico
+*.bmp
+*.tiff
+
+# Docs / papers (graphify DOC_EXTENSIONS + PAPER_EXTENSIONS)
+*.md
+*.mdx
+*.qmd
+*.txt
+*.rst
+*.html
+*.yaml
+*.yml
+*.pdf
+# extra office/text formats (not graphify-native, excluded for cleanliness)
+*.doc
+*.docx
+*.ppt
+*.pptx
+*.csv


### PR DESCRIPTION
## What
Adds graphify code knowledge graph CI to augustus via the new shared reusable in public-workflows ([PR #104](https://github.com/praetorian-inc/public-workflows/pull/104)):
- `.github/workflows/graphify-graph.yml` — caller (build graph → publish `augustus-graph` artifact)
- `.graphifyignore` — keyless code-only baseline (no LLM key)
- `.gitignore` — `graphify-out/`

## Why
Part of the multi-repo graphify rollout (small test: **pius, augustus, guard-core**). CI builds the graph once; engineers/agents pull the artifact: `gh run download -R praetorian-inc/augustus -n augustus-graph -D graphify-out`.

## Validation
The `pull_request` trigger builds augustus's graph **on this PR** — watch the `graph` check for a non-empty artifact. After merge, push-to-main + weekly keep it fresh.

## ⚠️ Pin note
Pinned to the reusable's **PR #104 branch SHA** (`b9d06c5`) for validation now. **Re-pin to the `vX.Y.Z` release tag after #104 merges + tags before final merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)