### PR TITLE
ci(graphify): re-pin reusable to v2.9.3

### DIFF
--- a/.github/workflows/graphify-graph.yml
+++ b/.github/workflows/graphify-graph.yml
@@ -33,6 +33,6 @@ permissions:
 jobs:
   graph:
     # Re-pin to the public-workflows release tag once PR #104 merges + tags.
-    uses: praetorian-inc/public-workflows/.github/workflows/graphify-graph.yml@c81c12f1aae98b023e1aea25077c58a628857b6c  # v2.9.0
+    uses: praetorian-inc/public-workflows/.github/workflows/graphify-graph.yml@0c602372f3d0d038912dd08e159ecc83954a4995  # v2.9.3
     permissions:
       contents: read


### PR DESCRIPTION
Re-pins the shared `public-workflows` graphify reusable v2.9.0 → v2.9.3 (`c81c12f` → `0c60237`). Reusable file is byte-identical across these tags; version-label hygiene only. Brings augustus in line with the capabilities-wide v2.9.3 pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)