### PR TITLE
chore(ci): drop obsolete pull-requests:read from go-sec/titus-scan callers

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -23,7 +23,6 @@ jobs:
       contents: read
       security-events: write
       actions: read
-      pull-requests: read
     with:
       fail-on-findings: true
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,7 +27,6 @@ jobs:
     uses: praetorian-inc/public-workflows/.github/workflows/go-sec.yml@0c602372f3d0d038912dd08e159ecc83954a4995  # v2.9.3
     permissions:
       contents: read
-      pull-requests: read     # go-sec.yml preflight reads PR files + repo tree
       security-events: write
       actions: read           # required by codeql-action/upload-sarif for run metadata
     secrets: inherit


### PR DESCRIPTION
augustus already pins public-workflows v2.9.3, whose go-sec/titus-scan preflights detect changed files via the commits compare API (needs only contents:read). The leftover pull-requests:read grants on the go-sec caller (security.yml) and titus-scan caller (secrets-scan.yml) — added as a stopgap during the preflight-permissions regression — are now obsolete and removed. ci.yml was already cleaned in PR #131. Reviewer workflows keep pull-requests:write (they post PR comments).