### PR TITLE
fix(toolcoercion): set probe severity to low

### DIFF
--- a/internal/probes/toolcoercion/data/AuthorityInjection.yaml
+++ b/internal/probes/toolcoercion/data/AuthorityInjection.yaml
@@ -10,7 +10,7 @@ info:
     - agent
     - tool-coercion
     - authority-injection
-  severity: critical
+  severity: low
   references:
     - https://arxiv.org/abs/2504.19793
   cwe:

--- a/internal/probes/toolcoercion/data/CausalityLaundering.yaml
+++ b/internal/probes/toolcoercion/data/CausalityLaundering.yaml
@@ -12,7 +12,7 @@ info:
     - causality-laundering
     - side-channel
     - information-leakage
-  severity: critical
+  severity: low
   references:
     - https://arxiv.org/abs/2604.04035
   cwe:

--- a/internal/probes/toolcoercion/data/DeprecationClaim.yaml
+++ b/internal/probes/toolcoercion/data/DeprecationClaim.yaml
@@ -11,7 +11,7 @@ info:
     - tool-coercion
     - deprecation
     - social-engineering
-  severity: critical
+  severity: low
   references:
     - https://arxiv.org/abs/2504.19793
   cwe:

--- a/internal/probes/toolcoercion/data/HaystackDilution.yaml
+++ b/internal/probes/toolcoercion/data/HaystackDilution.yaml
@@ -10,7 +10,7 @@ info:
     - agent
     - tool-coercion
     - haystack
-  severity: high
+  severity: low
   references:
     - https://arxiv.org/abs/2504.19793
   cwe:

--- a/internal/probes/toolcoercion/data/InstructionEmbed.yaml
+++ b/internal/probes/toolcoercion/data/InstructionEmbed.yaml
@@ -10,7 +10,7 @@ info:
     - agent
     - tool-coercion
     - instruction-injection
-  severity: critical
+  severity: low
   references:
     - https://arxiv.org/abs/2504.19793
   cwe:

--- a/internal/probes/toolcoercion/data/MCPToolPoison.yaml
+++ b/internal/probes/toolcoercion/data/MCPToolPoison.yaml
@@ -12,7 +12,7 @@ info:
     - mcp
     - tool-poisoning
     - prompt-injection
-  severity: critical
+  severity: low
   references:
     - https://arxiv.org/abs/2603.18063
     - https://arxiv.org/abs/2504.03767

--- a/internal/probes/toolcoercion/data/ParasiticChain.yaml
+++ b/internal/probes/toolcoercion/data/ParasiticChain.yaml
@@ -12,7 +12,7 @@ info:
     - mcp
     - parasitic-chaining
     - tool-poisoning
-  severity: critical
+  severity: low
   references:
     - https://arxiv.org/abs/2603.18063
   cwe:

--- a/internal/probes/toolcoercion/data/SemanticLure.yaml
+++ b/internal/probes/toolcoercion/data/SemanticLure.yaml
@@ -10,7 +10,7 @@ info:
     - agent
     - tool-coercion
     - semantic-similarity
-  severity: critical
+  severity: low
   references:
     - https://arxiv.org/abs/2504.19793
   cwe:


### PR DESCRIPTION
## Summary

Lowers the `severity` on all 8 tool-coercion probes added in #112 from **critical** (7 probes) / **high** (1 probe, `HaystackDilution`) to **low**.

These are shallow, single-turn tool-*selection* tests: each prompt presents a tool list containing one poisoned description and asks the model only to **name or describe** which tool it would pick. No tool executes, no data is exfiltrated, and there is no multi-turn agent loop. A "vulnerable" verdict therefore reflects a selection-preference signal, not a demonstrated end-to-end compromise — so `low` matches the actual depth of the test.

`HaystackDilution` is the same selection test with more decoy tools (a difficulty knob, not a higher-impact attack), so `low` fits it as well.

## Files

| Probe | Was | Now |
|-------|-----|-----|
| AuthorityInjection | critical | low |
| InstructionEmbed | critical | low |
| ParasiticChain | critical | low |
| MCPToolPoison | critical | low |
| SemanticLure | critical | low |
| CausalityLaundering | critical | low |
| DeprecationClaim | critical | low |
| HaystackDilution | high | low |

## Notes

- **No functional impact.** `ProbeInfo.Severity` is validated (`pkg/templates/types.go`) against `{critical, high, medium, low, info}` but is **not consumed** anywhere in the scan, scoring, reporting, or attempt-metadata paths. This is a descriptive-accuracy change.
- Caveat for the future: the underlying classes (parasitic chaining, MCP tool poisoning, causality laundering) would warrant higher severity **if** these graduate to real tool-execution or multi-turn agent probes. As written, `low` is correct.
- `go test ./internal/probes/toolcoercion/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)