### PR TITLE
fix: populate Metrics.TokensConsumed and make Metrics self-synchronizing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,9 @@ Probes may also implement these **optional** interfaces (all in `pkg/types/probe
 - **ProbeSecondaryDetectors**: `GetSecondaryDetectors()` — run extra detectors alongside the primary; the attempt verdict reflects the **max score across all detectors** (see `attempt.GetEffectiveScores`), so a secondary hit alone marks the attempt vulnerable
 - **ProbeTools**: `GetTools()` / `GetToolChoice()` — declare function-calling tool schemas for tool-use/agent probes (sent via the native wire layer in `internal/attackengine/toolcalls.go`)
 
+Generators may also implement this **optional** interface (in `pkg/types/generator.go`):
+- **UsageReporter**: `AccumulatedTokens() int64` — reports the cumulative tokens consumed across all `Generate` calls. The scanner type-asserts each generator for this interface and records the per-run delta into `Metrics.TokensConsumed` (surfaced as `augustus_tokens_consumed`). Implement it for free by embedding `types.UsageCounter` (a concurrency-safe `atomic.Int64`) and calling `g.AddTokens(...)` wherever the provider returns usage. Generators whose provider doesn't report usage still embed `UsageCounter` and simply never `AddTokens`, contributing 0 (honest partial coverage, never an estimate).
+
 ### Plugin Registration Pattern
 
 Capabilities self-register via `init()` functions. Example:
@@ -101,6 +104,7 @@ For YAML-based probes, create `.yaml` files in `data/` subdirectory and use `tem
 2. Implement `types.Generator` interface
 3. Register: `generators.Register("provider.Name", factory)`
 4. Handle configuration via `registry.Config` map
+5. Embed `types.UsageCounter` (satisfies the optional `UsageReporter`) and call `g.AddTokens(...)` at each usage-parse site so the provider's token counts flow into `Metrics.TokensConsumed`; leave it un-incremented if the provider returns no usage
 
 ### New Detector
 

--- a/internal/generators/anthropic/anthropic.go
+++ b/internal/generators/anthropic/anthropic.go
@@ -23,6 +23,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -40,6 +41,8 @@ const (
 
 // Anthropic is a generator that wraps the Anthropic Messages API.
 type Anthropic struct {
+	types.UsageCounter // embedded; provides AccumulatedTokens()
+
 	apiKey     string
 	baseURL    string
 	apiVersion string
@@ -309,6 +312,9 @@ func (g *Anthropic) generateOne(ctx context.Context, conv *attempt.Conversation)
 	if err := json.Unmarshal(respBody, &resp); err != nil {
 		return attempt.Message{}, fmt.Errorf("anthropic: failed to parse response: %w", err)
 	}
+
+	// Accumulate token usage per call (input + output).
+	g.AddTokens(int64(resp.Usage.InputTokens + resp.Usage.OutputTokens))
 
 	// Extract text and tool_use blocks from content.
 	var text string

--- a/internal/generators/azure/azure.go
+++ b/internal/generators/azure/azure.go
@@ -25,6 +25,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -48,6 +49,8 @@ var completionModels = openaicompat.CompletionModels
 
 // AzureOpenAI is a generator that wraps the Azure OpenAI API.
 type AzureOpenAI struct {
+	types.UsageCounter // embedded; provides AccumulatedTokens()
+
 	client *goopenai.Client
 	model  string
 	isChat bool
@@ -182,6 +185,7 @@ func (g *AzureOpenAI) generateChat(ctx context.Context, conv *attempt.Conversati
 	if err != nil {
 		return nil, openaicompat.WrapError("azure openai", err)
 	}
+	g.AddTokens(int64(resp.Usage.TotalTokens))
 
 	// Extract responses from choices
 	responses := make([]attempt.Message, 0, len(resp.Choices))
@@ -227,6 +231,7 @@ func (g *AzureOpenAI) generateCompletion(ctx context.Context, conv *attempt.Conv
 	if err != nil {
 		return nil, openaicompat.WrapError("azure openai", err)
 	}
+	g.AddTokens(int64(resp.Usage.TotalTokens))
 
 	// Extract responses from choices
 	responses := make([]attempt.Message, 0, len(resp.Choices))

--- a/internal/generators/bedrock/bedrock.go
+++ b/internal/generators/bedrock/bedrock.go
@@ -24,6 +24,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -38,6 +39,8 @@ const (
 
 // Bedrock is a generator that wraps the AWS Bedrock Runtime API.
 type Bedrock struct {
+	types.UsageCounter // embedded; provides AccumulatedTokens()
+
 	client    *bedrockruntime.Client
 	modelID   string
 	region    string
@@ -165,17 +168,21 @@ func (g *Bedrock) generateOne(ctx context.Context, conv *attempt.Conversation) (
 
 	// Parse response based on model type
 	var text string
+	var tokens int64
 	if strings.HasPrefix(g.modelID, "anthropic.claude") {
-		text, err = g.parseClaudeResponse(output.Body)
+		text, tokens, err = g.parseClaudeResponse(output.Body)
 	} else if strings.HasPrefix(g.modelID, "amazon.titan") {
-		text, err = g.parseTitanResponse(output.Body)
+		text, tokens, err = g.parseTitanResponse(output.Body)
 	} else if strings.HasPrefix(g.modelID, "meta.llama") {
-		text, err = g.parseLlamaResponse(output.Body)
+		text, tokens, err = g.parseLlamaResponse(output.Body)
 	}
 
 	if err != nil {
 		return attempt.Message{}, fmt.Errorf("bedrock: failed to parse response: %w", err)
 	}
+
+	// Accumulate token usage per call.
+	g.AddTokens(tokens)
 
 	return attempt.NewAssistantMessage(text), nil
 }
@@ -219,17 +226,22 @@ func (g *Bedrock) buildClaudeRequest(conv *attempt.Conversation) ([]byte, error)
 }
 
 // parseClaudeResponse parses a response from Anthropic Claude models on Bedrock.
-func (g *Bedrock) parseClaudeResponse(body []byte) (string, error) {
+// It returns the generated text and the total token usage (input + output).
+func (g *Bedrock) parseClaudeResponse(body []byte) (string, int64, error) {
 	var resp struct {
 		Content []struct {
 			Type string `json:"type"`
 			Text string `json:"text"`
 		} `json:"content"`
 		StopReason string `json:"stop_reason"`
+		Usage      struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
 	}
 
 	if err := json.Unmarshal(body, &resp); err != nil {
-		return "", err
+		return "", 0, err
 	}
 
 	var text string
@@ -239,7 +251,7 @@ func (g *Bedrock) parseClaudeResponse(body []byte) (string, error) {
 		}
 	}
 
-	return text, nil
+	return text, int64(resp.Usage.InputTokens + resp.Usage.OutputTokens), nil
 }
 
 // buildTitanRequest builds a request for Amazon Titan models on Bedrock.
@@ -275,22 +287,30 @@ func (g *Bedrock) buildTitanRequest(conv *attempt.Conversation) ([]byte, error) 
 }
 
 // parseTitanResponse parses a response from Amazon Titan models on Bedrock.
-func (g *Bedrock) parseTitanResponse(body []byte) (string, error) {
+// It returns the generated text and the total token usage (input + output).
+func (g *Bedrock) parseTitanResponse(body []byte) (string, int64, error) {
 	var resp struct {
-		Results []struct {
+		InputTextTokenCount int `json:"inputTextTokenCount"`
+		Results             []struct {
 			OutputText string `json:"outputText"`
+			TokenCount int    `json:"tokenCount"`
 		} `json:"results"`
 	}
 
 	if err := json.Unmarshal(body, &resp); err != nil {
-		return "", err
+		return "", 0, err
 	}
 
 	if len(resp.Results) == 0 {
-		return "", fmt.Errorf("no results in Titan response")
+		return "", 0, fmt.Errorf("no results in Titan response")
 	}
 
-	return resp.Results[0].OutputText, nil
+	tokens := int64(resp.InputTextTokenCount)
+	for _, r := range resp.Results {
+		tokens += int64(r.TokenCount)
+	}
+
+	return resp.Results[0].OutputText, tokens, nil
 }
 
 // buildLlamaRequest builds a request for Meta Llama models on Bedrock.
@@ -329,16 +349,19 @@ func (g *Bedrock) buildLlamaRequest(conv *attempt.Conversation) ([]byte, error) 
 }
 
 // parseLlamaResponse parses a response from Meta Llama models on Bedrock.
-func (g *Bedrock) parseLlamaResponse(body []byte) (string, error) {
+// It returns the generated text and the total token usage (prompt + generation).
+func (g *Bedrock) parseLlamaResponse(body []byte) (string, int64, error) {
 	var resp struct {
-		Generation string `json:"generation"`
+		Generation           string `json:"generation"`
+		PromptTokenCount     int    `json:"prompt_token_count"`
+		GenerationTokenCount int    `json:"generation_token_count"`
 	}
 
 	if err := json.Unmarshal(body, &resp); err != nil {
-		return "", err
+		return "", 0, err
 	}
 
-	return resp.Generation, nil
+	return resp.Generation, int64(resp.PromptTokenCount + resp.GenerationTokenCount), nil
 }
 
 // handleError processes API errors.

--- a/internal/generators/cohere/cohere.go
+++ b/internal/generators/cohere/cohere.go
@@ -23,6 +23,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 const (
@@ -44,6 +45,8 @@ func init() {
 
 // Cohere is a generator that wraps the Cohere API.
 type Cohere struct {
+	types.UsageCounter // embedded; provides AccumulatedTokens()
+
 	client  *http.Client
 	baseURL string
 	apiKey  string
@@ -184,6 +187,9 @@ func (g *Cohere) callChatAPI(ctx context.Context, conv *attempt.Conversation) (a
 	if err := json.NewDecoder(resp.Body).Decode(&chatResp); err != nil {
 		return attempt.Message{}, fmt.Errorf("cohere: failed to decode response: %w", err)
 	}
+
+	// Accumulate token usage per call (v2: usage.tokens).
+	g.AddTokens(int64(chatResp.Usage.Tokens.InputTokens + chatResp.Usage.Tokens.OutputTokens))
 
 	// Extract text content and tool calls
 	text := g.extractChatContent(chatResp)
@@ -436,6 +442,9 @@ func (g *Cohere) callGenerateAPI(ctx context.Context, conv *attempt.Conversation
 		return nil, fmt.Errorf("cohere: failed to decode response: %w", err)
 	}
 
+	// Accumulate token usage per batch call (v1: meta.billed_units).
+	g.AddTokens(int64(genResp.Meta.BilledUnits.InputTokens + genResp.Meta.BilledUnits.OutputTokens))
+
 	// Extract generations
 	responses := make([]attempt.Message, 0, len(genResp.Generations))
 	for _, gen := range genResp.Generations {
@@ -487,6 +496,15 @@ type chatResponse struct {
 	ID           string         `json:"id"`
 	FinishReason string         `json:"finish_reason"`
 	Message      messageContent `json:"message"`
+	Usage        cohereV2Usage  `json:"usage"`
+}
+
+// cohereV2Usage represents v2 token usage (usage.tokens.{input,output}_tokens).
+type cohereV2Usage struct {
+	Tokens struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+	} `json:"tokens"`
 }
 
 // messageContent represents message content in a chat response.
@@ -519,6 +537,15 @@ type cohereResponseToolFunction struct {
 type generateResponse struct {
 	ID          string       `json:"id"`
 	Generations []generation `json:"generations"`
+	Meta        cohereV1Meta `json:"meta"`
+}
+
+// cohereV1Meta represents v1 token usage (meta.billed_units.{input,output}_tokens).
+type cohereV1Meta struct {
+	BilledUnits struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+	} `json:"billed_units"`
 }
 
 // generation represents a single generation in a v1 response.

--- a/internal/generators/function/function.go
+++ b/internal/generators/function/function.go
@@ -15,6 +15,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -33,7 +34,8 @@ type MultipleFunc func(string, int) []string
 // Single is a generator that wraps a user-provided function for single responses.
 // The function is called once regardless of the n parameter.
 type Single struct {
-	fn SingleFunc
+	types.UsageCounter // embedded but never incremented: in-process function returns no token usage.
+	fn                 SingleFunc
 }
 
 // NewSingle creates a new Single generator from configuration.
@@ -88,7 +90,8 @@ func (s *Single) Description() string {
 // Multiple is a generator that wraps a user-provided function for multiple responses.
 // The function is called with the n parameter and should return n responses.
 type Multiple struct {
-	fn MultipleFunc
+	types.UsageCounter // embedded but never incremented: in-process function returns no token usage.
+	fn                 MultipleFunc
 }
 
 // NewMultiple creates a new Multiple generator from configuration.

--- a/internal/generators/ggml/ggml.go
+++ b/internal/generators/ggml/ggml.go
@@ -29,6 +29,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -40,8 +41,9 @@ var ggufMagic = []byte{0x47, 0x47, 0x55, 0x46}
 
 // Ggml is a generator that executes GGML models via subprocess.
 type Ggml struct {
-	ggmlMainPath string
-	modelPath    string
+	types.UsageCounter // embedded but never incremented: ggml subprocess returns no token usage.
+	ggmlMainPath       string
+	modelPath          string
 
 	// Generation parameters
 	temperature   float64

--- a/internal/generators/guardrails/nemoguardrails.go
+++ b/internal/generators/guardrails/nemoguardrails.go
@@ -16,6 +16,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -24,10 +25,11 @@ func init() {
 
 // NeMoGuardrails is a generator that wraps the NeMo Guardrails HTTP API.
 type NeMoGuardrails struct {
-	client      *http.Client
-	baseURL     string
-	apiKey      string
-	railsConfig string
+	types.UsageCounter // embedded but never incremented: NeMo Guardrails returns no token usage.
+	client             *http.Client
+	baseURL            string
+	apiKey             string
+	railsConfig        string
 }
 
 // NewNeMoGuardrails creates a new NeMo Guardrails generator from configuration.

--- a/internal/generators/huggingface/inference.go
+++ b/internal/generators/huggingface/inference.go
@@ -14,6 +14,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	libhttp "github.com/praetorian-inc/augustus/pkg/lib/http"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 const (
@@ -33,9 +34,10 @@ func init() {
 
 // InferenceAPI generates text using HuggingFace's hosted inference.
 type InferenceAPI struct {
-	client  *libhttp.Client
-	model   string
-	baseURL string
+	types.UsageCounter // embedded but never incremented: HF inference API returns no token usage.
+	client             *libhttp.Client
+	model              string
+	baseURL            string
 
 	// Configuration
 	maxTokens      int

--- a/internal/generators/huggingface/inferenceendpoint.go
+++ b/internal/generators/huggingface/inferenceendpoint.go
@@ -14,6 +14,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	libhttp "github.com/praetorian-inc/augustus/pkg/lib/http"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 const (
@@ -27,8 +28,9 @@ func init() {
 
 // InferenceEndpoint generates text using a custom HuggingFace Inference Endpoint.
 type InferenceEndpoint struct {
-	client      *libhttp.Client
-	endpointURL string
+	types.UsageCounter // embedded but never incremented: HF inference endpoint returns no token usage.
+	client             *libhttp.Client
+	endpointURL        string
 
 	// Configuration
 	maxTokens int

--- a/internal/generators/huggingface/llava.go
+++ b/internal/generators/huggingface/llava.go
@@ -13,6 +13,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	libhttp "github.com/praetorian-inc/augustus/pkg/lib/http"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -22,9 +23,10 @@ func init() {
 // LLaVA generates text from vision-language inputs using HuggingFace's hosted LLaVA models.
 // This supports multimodal (text + image) inputs.
 type LLaVA struct {
-	client  *libhttp.Client
-	model   string
-	baseURL string
+	types.UsageCounter // embedded but never incremented: HF LLaVA returns no token usage.
+	client             *libhttp.Client
+	model              string
+	baseURL            string
 
 	// Configuration
 	maxTokens    int

--- a/internal/generators/huggingface/pipeline.go
+++ b/internal/generators/huggingface/pipeline.go
@@ -41,6 +41,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	libhttp "github.com/praetorian-inc/augustus/pkg/lib/http"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 const (
@@ -58,9 +59,10 @@ func init() {
 
 // Pipeline generates text using a locally-run HuggingFace model via TGI.
 type Pipeline struct {
-	client *libhttp.Client
-	model  string
-	host   string
+	types.UsageCounter // embedded; provides AccumulatedTokens()
+	client             *libhttp.Client
+	model              string
+	host               string
 
 	// Configuration
 	maxTokens      int
@@ -225,11 +227,17 @@ func (g *Pipeline) parseResponse(resp *libhttp.Response) ([]attempt.Message, err
 				Content string `json:"content"`
 			} `json:"message"`
 		} `json:"choices"`
+		Usage struct {
+			TotalTokens int `json:"total_tokens"`
+		} `json:"usage"`
 	}
 
 	if err := resp.JSON(&result); err != nil {
 		return nil, fmt.Errorf("huggingface: failed to parse TGI response: %w", err)
 	}
+
+	// Accumulate token usage reported by the TGI server (OpenAI-compatible aggregate).
+	g.AddTokens(int64(result.Usage.TotalTokens))
 
 	messages := make([]attempt.Message, 0, len(result.Choices))
 	for _, choice := range result.Choices {

--- a/internal/generators/langchain/langchain.go
+++ b/internal/generators/langchain/langchain.go
@@ -18,6 +18,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -27,8 +28,9 @@ func init() {
 // LangChain is a generator that wraps LangChain LLM interfaces via REST API.
 // It calls the invoke() method on the LangChain endpoint.
 type LangChain struct {
-	uri    string
-	client *http.Client
+	types.UsageCounter // embedded but never incremented: LangChain invoke returns no token usage.
+	uri                string
+	client             *http.Client
 }
 
 // NewLangChain creates a new LangChain generator from configuration.

--- a/internal/generators/langchainserve/langchainserve.go
+++ b/internal/generators/langchainserve/langchainserve.go
@@ -18,6 +18,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -27,10 +28,11 @@ func init() {
 // LangChainServe is a generator that wraps LangChain Serve applications via REST API.
 // It calls the /invoke endpoint on the LangChain Serve application.
 type LangChainServe struct {
-	baseURL    string
-	configHash string
-	headers    map[string]string
-	client     *http.Client
+	types.UsageCounter // embedded but never incremented: LangChain Serve returns no token usage.
+	baseURL            string
+	configHash         string
+	headers            map[string]string
+	client             *http.Client
 }
 
 // NewLangChainServe creates a new LangChainServe generator from configuration.

--- a/internal/generators/litellm/litellm.go
+++ b/internal/generators/litellm/litellm.go
@@ -12,6 +12,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -37,6 +38,8 @@ var unsupportedMultipleGenProviders = []string{
 
 // LiteLLM is a generator that connects to a LiteLLM proxy server.
 type LiteLLM struct {
+	types.UsageCounter // embedded; provides AccumulatedTokens()
+
 	client *goopenai.Client
 	model  string
 
@@ -137,6 +140,7 @@ func (g *LiteLLM) generateWithN(ctx context.Context, conv *attempt.Conversation,
 	if err != nil {
 		return nil, openaicompat.WrapError("litellm", err)
 	}
+	g.AddTokens(int64(resp.Usage.TotalTokens))
 
 	responses := make([]attempt.Message, 0, len(resp.Choices))
 	for _, choice := range resp.Choices {
@@ -158,6 +162,7 @@ func (g *LiteLLM) generateMultipleCalls(ctx context.Context, conv *attempt.Conve
 		if err != nil {
 			return nil, openaicompat.WrapError("litellm", err)
 		}
+		g.AddTokens(int64(resp.Usage.TotalTokens))
 
 		if len(resp.Choices) > 0 {
 			responses = append(responses, attempt.NewAssistantMessage(resp.Choices[0].Message.Content))

--- a/internal/generators/nim/completion.go
+++ b/internal/generators/nim/completion.go
@@ -9,11 +9,13 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 // NVOpenAICompletion is a generator that wraps NVIDIA NIM completion endpoints.
 // Unlike NIM (which uses chat/completions), this uses the v1/completions endpoint.
 type NVOpenAICompletion struct {
+	types.UsageCounter // embedded; provides AccumulatedTokens()
 	Config
 }
 
@@ -56,6 +58,7 @@ func (g *NVOpenAICompletion) Generate(ctx context.Context, conv *attempt.Convers
 	if err != nil {
 		return nil, openaicompat.WrapError("nim", err)
 	}
+	g.AddTokens(int64(resp.Usage.TotalTokens))
 
 	// Extract responses from choices
 	responses := make([]attempt.Message, 0, len(resp.Choices))

--- a/internal/generators/nim/multimodal.go
+++ b/internal/generators/nim/multimodal.go
@@ -9,11 +9,13 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 // NVMultimodal is a generator that wraps NVIDIA NIM multimodal endpoints.
 // Supports text, image, and audio inputs.
 type NVMultimodal struct {
+	types.UsageCounter // embedded; provides AccumulatedTokens() (shared by Vision via pointer embed)
 	Config
 }
 
@@ -56,6 +58,7 @@ func (g *NVMultimodal) Generate(ctx context.Context, conv *attempt.Conversation,
 	if err != nil {
 		return nil, openaicompat.WrapError("nim", err)
 	}
+	g.AddTokens(int64(resp.Usage.TotalTokens))
 
 	// Extract responses from choices
 	responses := make([]attempt.Message, 0, len(resp.Choices))

--- a/internal/generators/nvcf/nvcf.go
+++ b/internal/generators/nvcf/nvcf.go
@@ -16,6 +16,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 const (
@@ -30,10 +31,11 @@ func init() {
 
 // NvcfChat is a generator for NVCF chat completion models.
 type NvcfChat struct {
-	client     *http.Client
-	functionID string
-	apiKey     string
-	baseURL    string
+	types.UsageCounter // embedded; provides AccumulatedTokens() (shared by NvcfCompletion via pointer embed)
+	client             *http.Client
+	functionID         string
+	apiKey             string
+	baseURL            string
 
 	// Configuration parameters
 	temperature float32
@@ -128,6 +130,8 @@ func (g *NvcfChat) generateChat(ctx context.Context, conv *attempt.Conversation,
 		return nil, err
 	}
 
+	g.accumulateUsage(resp)
+
 	choices, ok := resp["choices"].([]any)
 	if !ok {
 		return nil, fmt.Errorf("nvcf: invalid response format - missing choices")
@@ -218,6 +222,21 @@ func (g *NvcfChat) makeRequest(ctx context.Context, url string, payload map[stri
 	return result, nil
 }
 
+// accumulateUsage reads usage.total_tokens from the decoded response map and
+// adds it to the token counter. Missing or malformed usage is treated as 0
+// (no panic) — total_tokens arrives as a JSON float64.
+func (g *NvcfChat) accumulateUsage(resp map[string]any) {
+	usage, ok := resp["usage"].(map[string]any)
+	if !ok {
+		return
+	}
+	total, ok := usage["total_tokens"].(float64)
+	if !ok {
+		return
+	}
+	g.AddTokens(int64(total))
+}
+
 func (g *NvcfChat) ClearHistory() {}
 
 func (g *NvcfChat) Name() string {
@@ -280,6 +299,8 @@ func (g *NvcfCompletion) generateCompletion(ctx context.Context, conv *attempt.C
 	if err != nil {
 		return nil, err
 	}
+
+	g.accumulateUsage(resp)
 
 	choices, ok := resp["choices"].([]any)
 	if !ok {

--- a/internal/generators/ollama/ollama.go
+++ b/internal/generators/ollama/ollama.go
@@ -25,6 +25,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -56,10 +57,12 @@ type generateRequest struct {
 
 // generateResponse is the response from /api/generate.
 type generateResponse struct {
-	Model    string `json:"model"`
-	Response string `json:"response"`
-	Done     bool   `json:"done"`
-	Error    string `json:"error,omitempty"`
+	Model           string `json:"model"`
+	Response        string `json:"response"`
+	Done            bool   `json:"done"`
+	PromptEvalCount int    `json:"prompt_eval_count"`
+	EvalCount       int    `json:"eval_count"`
+	Error           string `json:"error,omitempty"`
 }
 
 // chatMessage represents a message in a chat conversation.
@@ -78,14 +81,18 @@ type chatRequest struct {
 
 // chatResponse is the response from /api/chat.
 type chatResponse struct {
-	Model   string      `json:"model"`
-	Message chatMessage `json:"message"`
-	Done    bool        `json:"done"`
-	Error   string      `json:"error,omitempty"`
+	Model           string      `json:"model"`
+	Message         chatMessage `json:"message"`
+	Done            bool        `json:"done"`
+	PromptEvalCount int         `json:"prompt_eval_count"`
+	EvalCount       int         `json:"eval_count"`
+	Error           string      `json:"error,omitempty"`
 }
 
 // baseConfig holds common configuration for both Ollama generators.
 type baseConfig struct {
+	types.UsageCounter // embedded; provides AccumulatedTokens() (shared by Ollama + OllamaChat via pointer embed)
+
 	host        string
 	model       string
 	timeout     time.Duration
@@ -241,6 +248,9 @@ func (g *Ollama) callGenerate(ctx context.Context, prompt string) (attempt.Messa
 		return attempt.Message{}, fmt.Errorf("ollama: %s", genResp.Error)
 	}
 
+	// Accumulate token usage per call (prompt + generation eval counts).
+	g.AddTokens(int64(genResp.PromptEvalCount + genResp.EvalCount))
+
 	return attempt.NewAssistantMessage(genResp.Response), nil
 }
 
@@ -395,6 +405,9 @@ func (g *OllamaChat) callChat(ctx context.Context, messages []chatMessage) (atte
 	if chatResp.Error != "" {
 		return attempt.Message{}, fmt.Errorf("ollama: %s", chatResp.Error)
 	}
+
+	// Accumulate token usage per call (prompt + generation eval counts).
+	g.AddTokens(int64(chatResp.PromptEvalCount + chatResp.EvalCount))
 
 	return attempt.NewAssistantMessage(chatResp.Message.Content), nil
 }

--- a/internal/generators/openai/openai.go
+++ b/internal/generators/openai/openai.go
@@ -16,6 +16,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -30,6 +31,8 @@ var completionModels = openaicompat.CompletionModels
 
 // OpenAI is a generator that wraps the OpenAI API.
 type OpenAI struct {
+	types.UsageCounter // embedded; provides AccumulatedTokens()
+
 	client *goopenai.Client
 	model  string
 	isChat bool
@@ -187,6 +190,7 @@ func (g *OpenAI) generateChat(ctx context.Context, conv *attempt.Conversation, n
 	if err != nil {
 		return nil, openaicompat.WrapError("openai", err)
 	}
+	g.AddTokens(int64(resp.Usage.TotalTokens))
 
 	// Extract responses from choices, capturing any tool calls alongside text.
 	responses := make([]attempt.Message, 0, len(resp.Choices))
@@ -236,6 +240,7 @@ func (g *OpenAI) generateCompletion(ctx context.Context, conv *attempt.Conversat
 	if err != nil {
 		return nil, openaicompat.WrapError("openai", err)
 	}
+	g.AddTokens(int64(resp.Usage.TotalTokens))
 
 	// Extract responses from choices
 	responses := make([]attempt.Message, 0, len(resp.Choices))

--- a/internal/generators/openai/reasoning.go
+++ b/internal/generators/openai/reasoning.go
@@ -11,6 +11,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -23,6 +24,8 @@ func init() {
 // - Do NOT support n>1 (multiple generations)
 // - Do NOT support temperature parameter
 type OpenAIReasoning struct {
+	types.UsageCounter // embedded; provides AccumulatedTokens()
+
 	client *goopenai.Client
 	model  string
 
@@ -116,6 +119,7 @@ func (g *OpenAIReasoning) Generate(ctx context.Context, conv *attempt.Conversati
 	if err != nil {
 		return nil, openaicompat.WrapError("openai", err)
 	}
+	g.AddTokens(int64(resp.Usage.TotalTokens))
 
 	// Extract responses
 	if len(resp.Choices) == 0 {

--- a/internal/generators/openaicompat/openaicompat.go
+++ b/internal/generators/openaicompat/openaicompat.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 // ChatModels is the set of models that use the chat completions API.
@@ -191,6 +192,26 @@ func GenerateChat(
 	maxTokens int,
 	topP float32,
 ) ([]attempt.Message, error) {
+	// Delegate to the usage-aware implementation, discarding the token count to
+	// keep this function's signature backward-compatible (R4).
+	messages, _, err := GenerateChatWithUsage(ctx, client, providerName, model, conv, n, temperature, maxTokens, topP)
+	return messages, err
+}
+
+// GenerateChatWithUsage performs the same chat completion as GenerateChat but
+// also returns the total tokens reported by the provider (resp.Usage.TotalTokens).
+// CompatGenerator.Generate uses this to accumulate usage into its UsageCounter.
+func GenerateChatWithUsage(
+	ctx context.Context,
+	client *goopenai.Client,
+	providerName string,
+	model string,
+	conv *attempt.Conversation,
+	n int,
+	temperature float32,
+	maxTokens int,
+	topP float32,
+) ([]attempt.Message, int64, error) {
 	messages := ConversationToMessages(conv)
 
 	req := goopenai.ChatCompletionRequest{
@@ -212,7 +233,7 @@ func GenerateChat(
 
 	resp, err := client.CreateChatCompletion(ctx, req)
 	if err != nil {
-		return nil, WrapError(providerName, err)
+		return nil, 0, WrapError(providerName, err)
 	}
 
 	// Extract responses from choices
@@ -221,7 +242,7 @@ func GenerateChat(
 		responses = append(responses, attempt.NewAssistantMessage(choice.Message.Content))
 	}
 
-	return responses, nil
+	return responses, int64(resp.Usage.TotalTokens), nil
 }
 
 // RetryConfig holds retry behavior configuration for API calls.
@@ -255,15 +276,16 @@ type ProviderConfig struct {
 // CompatGenerator is a ready-to-use generator for OpenAI-compatible providers.
 // It implements the full Generator interface using shared openaicompat functions.
 type CompatGenerator struct {
-	client      *goopenai.Client
-	provider    string
-	name        string
-	description string
-	model       string
-	temperature float32
-	maxTokens   int
-	topP        float32
-	retryConfig *RetryConfig // Optional: nil means no retry
+	types.UsageCounter // embedded; provides AccumulatedTokens()
+	client             *goopenai.Client
+	provider           string
+	name               string
+	description        string
+	model              string
+	temperature        float32
+	maxTokens          int
+	topP               float32
+	retryConfig        *RetryConfig // Optional: nil means no retry
 }
 
 // NewGenerator creates a new CompatGenerator from registry config and provider settings.
@@ -336,7 +358,12 @@ func (g *CompatGenerator) Generate(ctx context.Context, conv *attempt.Conversati
 	if n <= 0 {
 		return []attempt.Message{}, nil
 	}
-	return GenerateChat(ctx, g.client, g.provider, g.model, conv, n, g.temperature, g.maxTokens, g.topP)
+	messages, tokens, err := GenerateChatWithUsage(ctx, g.client, g.provider, g.model, conv, n, g.temperature, g.maxTokens, g.topP)
+	if err != nil {
+		return nil, err
+	}
+	g.AddTokens(tokens)
+	return messages, nil
 }
 
 // ClearHistory is a no-op (stateless per call).

--- a/internal/generators/rasa/rasa.go
+++ b/internal/generators/rasa/rasa.go
@@ -16,6 +16,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -31,10 +32,11 @@ type Config struct {
 
 // RasaRest is a generator for Rasa chatbot framework REST API.
 type RasaRest struct {
-	baseURL string
-	model   string
-	sender  string
-	client  *http.Client
+	types.UsageCounter // embedded but never incremented: Rasa returns no token usage.
+	baseURL            string
+	model              string
+	sender             string
+	client             *http.Client
 }
 
 // NewRasaRest creates a new Rasa REST generator from configuration.

--- a/internal/generators/replicate/replicate.go
+++ b/internal/generators/replicate/replicate.go
@@ -28,6 +28,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -36,8 +37,9 @@ func init() {
 
 // Replicate is a generator that wraps the Replicate API.
 type Replicate struct {
-	client *replicatego.Client
-	model  string
+	types.UsageCounter // embedded but never incremented: Replicate SDK text path returns no token usage.
+	client             *replicatego.Client
+	model              string
 
 	// Configuration parameters
 	temperature       float32

--- a/internal/generators/rest/rest.go
+++ b/internal/generators/rest/rest.go
@@ -75,6 +75,7 @@ var (
 // Rest is a generic REST API generator that makes HTTP requests to configured endpoints.
 // It supports request templating, JSON response parsing, and various HTTP methods.
 type Rest struct {
+	types.UsageCounter // embedded but never incremented: REST endpoints return no token usage.
 	uri                string
 	method             string
 	headers            map[string]string

--- a/internal/generators/test/blank.go
+++ b/internal/generators/test/blank.go
@@ -7,6 +7,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -15,7 +16,9 @@ func init() {
 
 // Blank is the simplest generator - always returns empty responses.
 // Used for testing harness functionality without LLM access.
-type Blank struct{}
+type Blank struct {
+	types.UsageCounter // embedded but never incremented: test generator returns no token usage.
+}
 
 // NewBlank creates a new Blank generator.
 func NewBlank(_ registry.Config) (generators.Generator, error) {

--- a/internal/generators/test/blankvision.go
+++ b/internal/generators/test/blankvision.go
@@ -6,6 +6,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -14,7 +15,9 @@ func init() {
 
 // BlankVision is a test generator that returns empty responses for text+image input.
 // Useful for testing multimodal probe behavior without actual vision model access.
-type BlankVision struct{}
+type BlankVision struct {
+	types.UsageCounter // embedded but never incremented: test generator returns no token usage.
+}
 
 // NewBlankVision creates a new BlankVision generator.
 func NewBlankVision(_ registry.Config) (generators.Generator, error) {

--- a/internal/generators/test/lipsum.go
+++ b/internal/generators/test/lipsum.go
@@ -12,6 +12,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -21,7 +22,8 @@ func init() {
 // Lipsum is a test generator that returns Lorem Ipsum text.
 // Useful for testing probes with non-zero, varying outputs.
 type Lipsum struct {
-	rng *rand.Rand
+	types.UsageCounter // embedded but never incremented: test fake returns no token usage.
+	rng                *rand.Rand
 }
 
 // NewLipsum creates a new Lipsum generator.

--- a/internal/generators/test/nones.go
+++ b/internal/generators/test/nones.go
@@ -6,6 +6,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -14,7 +15,9 @@ func init() {
 
 // Nones is a test generator that always returns empty messages.
 // Supports multiple generations for testing probe handling of empty responses.
-type Nones struct{}
+type Nones struct {
+	types.UsageCounter // embedded but never incremented: test fake returns no token usage.
+}
 
 // NewNones creates a new Nones generator.
 func NewNones(_ registry.Config) (generators.Generator, error) {

--- a/internal/generators/test/repeat.go
+++ b/internal/generators/test/repeat.go
@@ -6,6 +6,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -15,7 +16,8 @@ func init() {
 // Repeat is a test generator that echoes the input prompt.
 // Useful for testing probes without LLM access.
 type Repeat struct {
-	prefix string
+	types.UsageCounter // embedded but never incremented: test fake returns no token usage.
+	prefix             string
 }
 
 // NewRepeat creates a new Repeat generator.

--- a/internal/generators/test/single.go
+++ b/internal/generators/test/single.go
@@ -7,6 +7,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -15,7 +16,9 @@ func init() {
 
 // Single is a test generator that returns a fixed string and refuses multiple generations.
 // Useful for testing that generation logic properly handles single-generation constraints.
-type Single struct{}
+type Single struct {
+	types.UsageCounter // embedded but never incremented: test fake returns no token usage.
+}
 
 // NewSingle creates a new Single generator.
 func NewSingle(_ registry.Config) (generators.Generator, error) {

--- a/internal/generators/vertex/vertex.go
+++ b/internal/generators/vertex/vertex.go
@@ -28,6 +28,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -44,6 +45,8 @@ const (
 
 // Vertex is a generator that wraps the Google Cloud Vertex AI API.
 type Vertex struct {
+	types.UsageCounter // embedded; provides AccumulatedTokens()
+
 	apiKey    string
 	baseURL   string
 	projectID string
@@ -355,6 +358,9 @@ func (g *Vertex) generateOne(ctx context.Context, conv *attempt.Conversation) (a
 	if err := json.Unmarshal(respBody, &resp); err != nil {
 		return attempt.Message{}, fmt.Errorf("vertex: failed to parse response: %w", err)
 	}
+
+	// Accumulate token usage per call.
+	g.AddTokens(int64(resp.UsageMetadata.TotalTokenCount))
 
 	// Extract text and function calls from first candidate
 	if len(resp.Candidates) == 0 {

--- a/internal/generators/watsonx/watsonx.go
+++ b/internal/generators/watsonx/watsonx.go
@@ -23,6 +23,7 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/registry"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 func init() {
@@ -37,17 +38,18 @@ const (
 
 // WatsonX is a generator that wraps the IBM Watson X API.
 type WatsonX struct {
-	client       *http.Client
-	apiKey       string
-	url          string
-	iamURL       string
-	projectID    string
-	deploymentID string
-	model        string
-	region       string
-	version      string
-	maxTokens    int
-	bearerToken  string
+	types.UsageCounter // embedded; provides AccumulatedTokens()
+	client             *http.Client
+	apiKey             string
+	url                string
+	iamURL             string
+	projectID          string
+	deploymentID       string
+	model              string
+	region             string
+	version            string
+	maxTokens          int
+	bearerToken        string
 }
 
 // NewWatsonX creates a new Watson X generator from configuration.
@@ -157,17 +159,21 @@ func (g *WatsonX) generateOne(ctx context.Context, conv *attempt.Conversation) (
 
 	// Choose generation method based on configuration
 	var text string
+	var tokens int64
 	var err error
 
 	if g.deploymentID != "" {
-		text, err = g.generateWithDeployment(ctx, promptText)
+		text, tokens, err = g.generateWithDeployment(ctx, promptText)
 	} else {
-		text, err = g.generateWithProject(ctx, promptText)
+		text, tokens, err = g.generateWithProject(ctx, promptText)
 	}
 
 	if err != nil {
 		return attempt.Message{}, err
 	}
+
+	// Accumulate token usage per call (input + generated).
+	g.AddTokens(tokens)
 
 	return attempt.NewAssistantMessage(text), nil
 }
@@ -210,7 +216,8 @@ func (g *WatsonX) setBearerToken(ctx context.Context) error {
 }
 
 // generateWithProject generates text using a project ID (development/training models).
-func (g *WatsonX) generateWithProject(ctx context.Context, prompt string) (string, error) {
+// It returns the generated text and the total tokens consumed (input + generated).
+func (g *WatsonX) generateWithProject(ctx context.Context, prompt string) (string, int64, error) {
 	apiURL := fmt.Sprintf("%s/ml/v1/text/generation?version=%s", g.url, g.version)
 
 	requestBody := map[string]any{
@@ -227,12 +234,12 @@ func (g *WatsonX) generateWithProject(ctx context.Context, prompt string) (strin
 
 	bodyBytes, err := json.Marshal(requestBody)
 	if err != nil {
-		return "", fmt.Errorf("watsonx: failed to marshal request: %w", err)
+		return "", 0, fmt.Errorf("watsonx: failed to marshal request: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(bodyBytes))
 	if err != nil {
-		return "", fmt.Errorf("watsonx: failed to create request: %w", err)
+		return "", 0, fmt.Errorf("watsonx: failed to create request: %w", err)
 	}
 
 	req.Header.Set("Accept", "application/json")
@@ -241,34 +248,38 @@ func (g *WatsonX) generateWithProject(ctx context.Context, prompt string) (strin
 
 	resp, err := g.client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("watsonx: request failed: %w", err)
+		return "", 0, fmt.Errorf("watsonx: request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return "", g.handleError(resp.StatusCode, body)
+		return "", 0, g.handleError(resp.StatusCode, body)
 	}
 
 	var result struct {
-		Results []struct {
-			GeneratedText string `json:"generated_text"`
+		InputTokenCount int `json:"input_token_count"`
+		Results         []struct {
+			GeneratedText       string `json:"generated_text"`
+			GeneratedTokenCount int    `json:"generated_token_count"`
 		} `json:"results"`
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", fmt.Errorf("watsonx: failed to decode response: %w", err)
+		return "", 0, fmt.Errorf("watsonx: failed to decode response: %w", err)
 	}
 
 	if len(result.Results) == 0 {
-		return "", fmt.Errorf("watsonx: no results in response")
+		return "", 0, fmt.Errorf("watsonx: no results in response")
 	}
 
-	return result.Results[0].GeneratedText, nil
+	tokens := int64(result.InputTokenCount + result.Results[0].GeneratedTokenCount)
+	return result.Results[0].GeneratedText, tokens, nil
 }
 
 // generateWithDeployment generates text using a deployment ID (production models).
-func (g *WatsonX) generateWithDeployment(ctx context.Context, prompt string) (string, error) {
+// It returns the generated text and the total tokens consumed (input + generated).
+func (g *WatsonX) generateWithDeployment(ctx context.Context, prompt string) (string, int64, error) {
 	apiURL := fmt.Sprintf("%s/ml/v1/deployments/%s/text/generation?version=%s",
 		g.url, g.deploymentID, g.version)
 
@@ -282,12 +293,12 @@ func (g *WatsonX) generateWithDeployment(ctx context.Context, prompt string) (st
 
 	bodyBytes, err := json.Marshal(requestBody)
 	if err != nil {
-		return "", fmt.Errorf("watsonx: failed to marshal request: %w", err)
+		return "", 0, fmt.Errorf("watsonx: failed to marshal request: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(bodyBytes))
 	if err != nil {
-		return "", fmt.Errorf("watsonx: failed to create request: %w", err)
+		return "", 0, fmt.Errorf("watsonx: failed to create request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -296,30 +307,33 @@ func (g *WatsonX) generateWithDeployment(ctx context.Context, prompt string) (st
 
 	resp, err := g.client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("watsonx: request failed: %w", err)
+		return "", 0, fmt.Errorf("watsonx: request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return "", g.handleError(resp.StatusCode, body)
+		return "", 0, g.handleError(resp.StatusCode, body)
 	}
 
 	var result struct {
-		Results []struct {
-			GeneratedText string `json:"generated_text"`
+		InputTokenCount int `json:"input_token_count"`
+		Results         []struct {
+			GeneratedText       string `json:"generated_text"`
+			GeneratedTokenCount int    `json:"generated_token_count"`
 		} `json:"results"`
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", fmt.Errorf("watsonx: failed to decode response: %w", err)
+		return "", 0, fmt.Errorf("watsonx: failed to decode response: %w", err)
 	}
 
 	if len(result.Results) == 0 {
-		return "", fmt.Errorf("watsonx: no results in response")
+		return "", 0, fmt.Errorf("watsonx: no results in response")
 	}
 
-	return result.Results[0].GeneratedText, nil
+	tokens := int64(result.InputTokenCount + result.Results[0].GeneratedTokenCount)
+	return result.Results[0].GeneratedText, tokens, nil
 }
 
 // handleError processes API errors.

--- a/internal/generators/watsonx/watsonx.go
+++ b/internal/generators/watsonx/watsonx.go
@@ -258,10 +258,10 @@ func (g *WatsonX) generateWithProject(ctx context.Context, prompt string) (strin
 	}
 
 	var result struct {
-		InputTokenCount int `json:"input_token_count"`
-		Results         []struct {
+		Results []struct {
 			GeneratedText       string `json:"generated_text"`
 			GeneratedTokenCount int    `json:"generated_token_count"`
+			InputTokenCount     int    `json:"input_token_count"`
 		} `json:"results"`
 	}
 
@@ -273,7 +273,7 @@ func (g *WatsonX) generateWithProject(ctx context.Context, prompt string) (strin
 		return "", 0, fmt.Errorf("watsonx: no results in response")
 	}
 
-	tokens := int64(result.InputTokenCount + result.Results[0].GeneratedTokenCount)
+	tokens := int64(result.Results[0].InputTokenCount + result.Results[0].GeneratedTokenCount)
 	return result.Results[0].GeneratedText, tokens, nil
 }
 
@@ -317,10 +317,10 @@ func (g *WatsonX) generateWithDeployment(ctx context.Context, prompt string) (st
 	}
 
 	var result struct {
-		InputTokenCount int `json:"input_token_count"`
-		Results         []struct {
+		Results []struct {
 			GeneratedText       string `json:"generated_text"`
 			GeneratedTokenCount int    `json:"generated_token_count"`
+			InputTokenCount     int    `json:"input_token_count"`
 		} `json:"results"`
 	}
 
@@ -332,7 +332,7 @@ func (g *WatsonX) generateWithDeployment(ctx context.Context, prompt string) (st
 		return "", 0, fmt.Errorf("watsonx: no results in response")
 	}
 
-	tokens := int64(result.InputTokenCount + result.Results[0].GeneratedTokenCount)
+	tokens := int64(result.Results[0].InputTokenCount + result.Results[0].GeneratedTokenCount)
 	return result.Results[0].GeneratedText, tokens, nil
 }
 

--- a/internal/generators/watsonx/watsonx_test.go
+++ b/internal/generators/watsonx/watsonx_test.go
@@ -279,6 +279,113 @@ func TestWatsonXGenerator_EmptyPromptHandling(t *testing.T) {
 	assert.Len(t, responses, 1)
 }
 
+// TestWatsonXGenerator_AccumulatesTokenUsage is a regression test for the
+// token-accounting bug where input_token_count was read at the top level of
+// the JSON response instead of from inside results[].  The mock already places
+// input_token_count:10 and generated_token_count:50 inside results[0], so the
+// fixed code must return 60 (10+50).  Under the old buggy code the input
+// tokens were always 0 (missing at top level), giving 50.  Both the project
+// path and the deployment path use the same decode struct, so both are covered.
+func TestWatsonXGenerator_AccumulatesTokenUsage(t *testing.T) {
+	t.Run("project path accumulates input+generated tokens", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(r.URL.Path, "/identity/token") {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"access_token": "test-bearer-token",
+					"expires_in":   3600,
+				})
+				return
+			}
+
+			if strings.Contains(r.URL.Path, "/ml/v1/text/generation") {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(mockWatsonXTextGenResponse("response"))
+				return
+			}
+
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		// NewWatsonX returns the Generator interface; keep the concrete *WatsonX
+		// so we can call AccumulatedTokens() without a type assertion.
+		watsonxGen, err := NewWatsonX(registry.Config{
+			"api_key":    "test-api-key",
+			"model":      "ibm/granite-13b-chat-v2",
+			"project_id": "test-project-id",
+			"region":     "us-south",
+			"url":        server.URL,
+			"iam_url":    server.URL + "/identity/token",
+		})
+		require.NoError(t, err)
+
+		// Type-assert to *WatsonX for AccumulatedTokens() access.
+		concreteGen, ok := watsonxGen.(*WatsonX)
+		require.True(t, ok, "NewWatsonX must return *WatsonX")
+
+		conv := attempt.NewConversation()
+		conv.AddPrompt("Hello")
+
+		responses, err := concreteGen.Generate(context.Background(), conv, 1)
+		require.NoError(t, err)
+		require.Len(t, responses, 1)
+
+		// mock: input_token_count=10 + generated_token_count=50 = 60
+		// buggy code would give 50 (input always decoded as 0 from top-level field)
+		assert.Equal(t, int64(60), concreteGen.AccumulatedTokens(),
+			"AccumulatedTokens should be 60 (10 input + 50 generated); "+
+				"50 would indicate the old bug where input_token_count was read from the top level")
+	})
+
+	t.Run("deployment path accumulates input+generated tokens", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(r.URL.Path, "/identity/token") {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"access_token": "test-bearer-token",
+					"expires_in":   3600,
+				})
+				return
+			}
+
+			if strings.Contains(r.URL.Path, "/ml/v1/deployments/") {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(mockWatsonXTextGenResponse("deployed response"))
+				return
+			}
+
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		watsonxGen, err := NewWatsonX(registry.Config{
+			"api_key":       "test-api-key",
+			"model":         "ibm/granite-13b-chat-v2",
+			"deployment_id": "test-deployment-id",
+			"region":        "us-south",
+			"url":           server.URL,
+			"iam_url":       server.URL + "/identity/token",
+		})
+		require.NoError(t, err)
+
+		concreteGen, ok := watsonxGen.(*WatsonX)
+		require.True(t, ok, "NewWatsonX must return *WatsonX")
+
+		conv := attempt.NewConversation()
+		conv.AddPrompt("Hello")
+
+		responses, err := concreteGen.Generate(context.Background(), conv, 1)
+		require.NoError(t, err)
+		require.Len(t, responses, 1)
+
+		// Same expectation: 10 input + 50 generated = 60
+		assert.Equal(t, int64(60), concreteGen.AccumulatedTokens(),
+			"AccumulatedTokens should be 60 (10 input + 50 generated); "+
+				"50 would indicate the old bug where input_token_count was read from the top level")
+	})
+}
+
 func TestWatsonXGenerator_MaxTokensConfiguration(t *testing.T) {
 	var requestBody map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/hooks/generator.go
+++ b/pkg/hooks/generator.go
@@ -10,8 +10,11 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
-// Compile-time interface assertion.
-var _ types.Generator = (*HookedGenerator)(nil)
+// Compile-time interface assertions.
+var (
+	_ types.Generator     = (*HookedGenerator)(nil)
+	_ types.UsageReporter = (*HookedGenerator)(nil)
+)
 
 // HookedGenerator wraps a generator with runtime hook support.
 // It runs the prepare hook before each Generate() call, merging
@@ -121,4 +124,14 @@ func (h *HookedGenerator) Name() string {
 // Description returns the inner generator's description.
 func (h *HookedGenerator) Description() string {
 	return h.inner.Description()
+}
+
+// AccumulatedTokens forwards to the inner generator if it reports usage;
+// otherwise returns 0. Without this forward, scans run through a prepare hook
+// would assert UsageReporter against this wrapper and read 0 tokens.
+func (h *HookedGenerator) AccumulatedTokens() int64 {
+	if r, ok := h.inner.(types.UsageReporter); ok {
+		return r.AccumulatedTokens()
+	}
+	return 0
 }

--- a/pkg/hooks/generator_test.go
+++ b/pkg/hooks/generator_test.go
@@ -11,7 +11,21 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/praetorian-inc/augustus/pkg/attempt"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
+
+// usageInnerGenerator is a test double that implements types.Generator AND
+// types.UsageReporter via the embedded types.UsageCounter.
+type usageInnerGenerator struct {
+	mockGenerator
+	types.UsageCounter
+	tokensPerCall int64
+}
+
+func (u *usageInnerGenerator) Generate(ctx context.Context, conv *attempt.Conversation, n int) ([]attempt.Message, error) {
+	u.AddTokens(u.tokensPerCall)
+	return u.mockGenerator.Generate(ctx, conv, n)
+}
 
 // mockGenerator is a test double for types.Generator.
 type mockGenerator struct {
@@ -318,4 +332,83 @@ func TestHookedGeneratorPrepareReceivesCurrentVars(t *testing.T) {
 	vars := VarsFromContext(inner.lastCtx)
 	require.NotNil(t, vars)
 	assert.Equal(t, "conv-999", vars["ECHOED"])
+}
+
+// ─── Category (v): ClearHistory preserves UsageCounter ───────────────────────
+
+// TestHookedGenerator_ClearHistory_PreservesUsage guards that ClearHistory
+// on a HookedGenerator does not reset the inner generator's token counter.
+func TestHookedGenerator_ClearHistory_PreservesUsage(t *testing.T) {
+	inner := &usageInnerGenerator{
+		mockGenerator: mockGenerator{
+			name:      "test.UsageMock",
+			responses: []attempt.Message{attempt.NewAssistantMessage("ok")},
+		},
+		tokensPerCall: 13,
+	}
+
+	hg := NewHookedGenerator(inner, nil, nil)
+	conv := attempt.NewConversation()
+	conv.AddPrompt("test")
+
+	_, err := hg.Generate(context.Background(), conv, 1)
+	require.NoError(t, err)
+
+	// inner has accumulated 13 tokens; forwarding must reflect it
+	require.Equal(t, int64(13), hg.AccumulatedTokens(), "AccumulatedTokens must forward inner's total")
+
+	hg.ClearHistory()
+
+	require.Equal(t, int64(13), hg.AccumulatedTokens(),
+		"ClearHistory must not reset the forwarded AccumulatedTokens")
+}
+
+// ─── Category (iv): Decorator forwarding ─────────────────────────────────────
+
+// TestHookedGenerator_ForwardsUsage proves that HookedGenerator forwards
+// AccumulatedTokens() to the inner generator when the inner implements
+// types.UsageReporter. This guards correction (b): without the forward,
+// scans run through a prepare hook would read 0 tokens.
+func TestHookedGenerator_ForwardsUsage(t *testing.T) {
+	const tokensPerCall = int64(7)
+	inner := &usageInnerGenerator{
+		mockGenerator: mockGenerator{
+			name:      "test.UsageMock",
+			responses: []attempt.Message{attempt.NewAssistantMessage("ok")},
+		},
+		tokensPerCall: tokensPerCall,
+	}
+
+	hg := NewHookedGenerator(inner, nil, nil)
+	conv := attempt.NewConversation()
+	conv.AddPrompt("test")
+
+	// First call
+	_, err := hg.Generate(context.Background(), conv, 1)
+	require.NoError(t, err)
+	require.Equal(t, tokensPerCall, hg.AccumulatedTokens(),
+		"after one Generate, wrapper must forward inner's accumulated tokens")
+
+	// Second call
+	_, err = hg.Generate(context.Background(), conv, 1)
+	require.NoError(t, err)
+	require.Equal(t, tokensPerCall*2, hg.AccumulatedTokens(),
+		"after two Generate calls, wrapper must forward inner's cumulative total")
+}
+
+// TestHookedGenerator_InnerNoUsage_Zero ensures that when the inner generator
+// does NOT implement UsageReporter, the wrapper returns 0 without panicking.
+func TestHookedGenerator_InnerNoUsage_Zero(t *testing.T) {
+	// mockGenerator does NOT embed types.UsageCounter → does not satisfy UsageReporter.
+	inner := &mockGenerator{
+		name:      "test.Plain",
+		responses: []attempt.Message{attempt.NewAssistantMessage("ok")},
+	}
+	hg := NewHookedGenerator(inner, nil, nil)
+
+	// Compile-time assertion: HookedGenerator still satisfies UsageReporter.
+	var _ types.UsageReporter = hg
+
+	assert.Equal(t, int64(0), hg.AccumulatedTokens(),
+		"wrapper around non-UsageReporter inner must return 0 without panicking")
 }

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -7,9 +7,10 @@ import (
 	"sync"
 )
 
-// Metrics tracks scan execution statistics.
-// Access to these fields must be protected by the caller's mutex.
+// Metrics tracks scan execution statistics. Safe for concurrent use:
+// all mutators and SnapshotLocked lock the embedded mutex.
 type Metrics struct {
+	mu              sync.Mutex // guards all fields below
 	ProbesTotal     int64
 	ProbesSucceeded int64
 	ProbesFailed    int64
@@ -18,12 +19,34 @@ type Metrics struct {
 	TokensConsumed  int64
 }
 
-// Snapshot returns a copy of the metrics with thread-safe access.
-// The caller must hold a mutex protecting the Metrics instance.
-func (m *Metrics) Snapshot(mu *sync.Mutex) MetricsSnapshot {
-	mu.Lock()
-	defer mu.Unlock()
+// RecordProbeResult records one probe completion under the internal lock.
+// On success it also adds the supplied attempt counts; on failure the attempt
+// counts are ignored.
+func (m *Metrics) RecordProbeResult(succeeded bool, totalAttempts, vulnAttempts int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ProbesTotal++
+	if succeeded {
+		m.ProbesSucceeded++
+		m.AttemptsTotal += totalAttempts
+		m.AttemptsVuln += vulnAttempts
+	} else {
+		m.ProbesFailed++
+	}
+}
 
+// AddTokens adds n to the cumulative token counter under the internal lock.
+func (m *Metrics) AddTokens(n int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.TokensConsumed += n
+}
+
+// SnapshotLocked returns a point-in-time copy of the metrics, taking the
+// internal lock. This is the preferred accessor; no external mutex required.
+func (m *Metrics) SnapshotLocked() MetricsSnapshot {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return MetricsSnapshot{
 		ProbesTotal:     m.ProbesTotal,
 		ProbesSucceeded: m.ProbesSucceeded,
@@ -32,6 +55,14 @@ func (m *Metrics) Snapshot(mu *sync.Mutex) MetricsSnapshot {
 		AttemptsVuln:    m.AttemptsVuln,
 		TokensConsumed:  m.TokensConsumed,
 	}
+}
+
+// Snapshot returns a copy of the metrics.
+//
+// Deprecated: the mu argument is ignored; Metrics now synchronizes internally.
+// Call SnapshotLocked instead.
+func (m *Metrics) Snapshot(_ *sync.Mutex) MetricsSnapshot {
+	return m.SnapshotLocked()
 }
 
 // MetricsSnapshot is a point-in-time copy of metrics values.
@@ -47,22 +78,22 @@ type MetricsSnapshot struct {
 // PrometheusExporter exports metrics in Prometheus text format
 type PrometheusExporter struct {
 	metrics *Metrics
-	mu      *sync.Mutex
 }
 
 // NewPrometheusExporter creates a new Prometheus exporter.
-// The provided mutex must be the same mutex used to protect metrics updates.
-func NewPrometheusExporter(m *Metrics, mu *sync.Mutex) *PrometheusExporter {
+//
+// Deprecated: the mu argument is ignored; Metrics now synchronizes internally.
+// The two-argument signature is retained only for backward compatibility.
+func NewPrometheusExporter(m *Metrics, _ *sync.Mutex) *PrometheusExporter {
 	return &PrometheusExporter{
 		metrics: m,
-		mu:      mu,
 	}
 }
 
 // Export returns metrics in Prometheus text format
 func (e *PrometheusExporter) Export() string {
-	// Get a thread-safe snapshot of metrics
-	snapshot := e.metrics.Snapshot(e.mu)
+	// Get a thread-safe snapshot of metrics via the internal lock.
+	snapshot := e.metrics.SnapshotLocked()
 
 	var b strings.Builder
 

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -10,7 +10,10 @@ import (
 // Metrics tracks scan execution statistics. Safe for concurrent use:
 // all mutators and SnapshotLocked lock the embedded mutex.
 type Metrics struct {
-	mu              sync.Mutex // guards all fields below
+	mu sync.Mutex // guards all fields below
+	// The exported fields below are retained for backward compatibility. Direct
+	// reads/writes are NOT synchronized — during a live scan, read a consistent
+	// view via SnapshotLocked(). Deprecated: prefer SnapshotLocked()/the mutator methods.
 	ProbesTotal     int64
 	ProbesSucceeded int64
 	ProbesFailed    int64
@@ -109,6 +112,9 @@ func (e *PrometheusExporter) Export() string {
 
 	// augustus_attempts_vulnerable
 	fmt.Fprintf(&b, "augustus_attempts_vulnerable %d\n", snapshot.AttemptsVuln)
+
+	// augustus_tokens_consumed
+	fmt.Fprintf(&b, "augustus_tokens_consumed %d\n", snapshot.TokensConsumed)
 
 	// augustus_attempts_vulnerability_rate (calculated metric)
 	var vulnRate float64

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPrometheusExporter_Export(t *testing.T) {
@@ -138,4 +141,131 @@ func formatFloatTest(f float64) string {
 	// Format to 2 decimal places, then trim trailing zeros
 	s := strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.2f", f), "0"), ".")
 	return s
+}
+
+// ─── Category (i): Concurrent writes + live snapshot (race test) ─────────────
+
+// TestMetrics_ConcurrentWritesAndSnapshot guards Issue B: 50 goroutines
+// concurrently calling RecordProbeResult and AddTokens while another goroutine
+// loops SnapshotLocked. Under -race this proves writers and the live reader
+// share one lock. Would flag a data race if any write bypassed the mutex.
+func TestMetrics_ConcurrentWritesAndSnapshot(t *testing.T) {
+	const workers = 50
+	m := &Metrics{}
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			m.RecordProbeResult(true, 2, 1)
+			m.AddTokens(10)
+		}()
+	}
+
+	// Concurrent reader: must not race with the writers above.
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		for i := 0; i < 1000; i++ {
+			_ = m.SnapshotLocked()
+		}
+	}()
+
+	wg.Wait()
+	<-readerDone
+
+	snapshot := m.SnapshotLocked()
+	require.Equal(t, int64(workers), snapshot.ProbesTotal, "ProbesTotal must equal worker count")
+	require.Equal(t, int64(workers), snapshot.ProbesSucceeded, "ProbesSucceeded must equal worker count")
+	require.Equal(t, int64(workers*2), snapshot.AttemptsTotal, "AttemptsTotal must be 2 per worker")
+	require.Equal(t, int64(workers), snapshot.AttemptsVuln, "AttemptsVuln must be 1 per worker")
+	require.Equal(t, int64(workers*10), snapshot.TokensConsumed, "TokensConsumed must be 10 per worker")
+}
+
+// TestMetrics_ConcurrentExportDuringScan guards the live /metrics-scrape-during-scan
+// scenario at the metrics-package level: PrometheusExporter.Export calls
+// SnapshotLocked while multiple goroutines write via RecordProbeResult.
+// A missing or wrong lock would surface under -race.
+func TestMetrics_ConcurrentExportDuringScan(t *testing.T) {
+	m := &Metrics{}
+	exporter := NewPrometheusExporter(m, nil)
+
+	var wg sync.WaitGroup
+	const writers = 30
+	wg.Add(writers)
+
+	for i := 0; i < writers; i++ {
+		go func() {
+			defer wg.Done()
+			m.RecordProbeResult(false, 0, 0)
+			m.AddTokens(5)
+		}()
+	}
+
+	// Concurrent reads via Export while writers are running.
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		for i := 0; i < 500; i++ {
+			out := exporter.Export()
+			// Export must always produce a non-empty output; never a zero-value partial read.
+			if !strings.Contains(out, "augustus_probes_total") {
+				panic("Export returned malformed output during concurrent writes")
+			}
+		}
+	}()
+
+	wg.Wait()
+	<-readerDone
+
+	snapshot := m.SnapshotLocked()
+	assert.Equal(t, int64(writers), snapshot.ProbesTotal)
+	assert.Equal(t, int64(writers*5), snapshot.TokensConsumed)
+}
+
+// ─── Category (vi, metrics-level): SnapshotLocked returns same data as Snapshot ──
+
+// TestMetrics_SnapshotLocked_EqualsSnapshot verifies that the new
+// SnapshotLocked() and the deprecated Snapshot(_ *sync.Mutex) return identical
+// snapshots for the same Metrics state (they share one code path).
+func TestMetrics_SnapshotLocked_EqualsSnapshot(t *testing.T) {
+	m := &Metrics{}
+	m.RecordProbeResult(true, 3, 1)
+	m.AddTokens(42)
+
+	preferred := m.SnapshotLocked()
+
+	//nolint:staticcheck // intentional deprecated-API backward-compat test
+	var freshMu sync.Mutex
+	//nolint:staticcheck // intentional deprecated-API backward-compat test
+	deprecated := m.Snapshot(&freshMu)
+
+	assert.Equal(t, preferred, deprecated, "SnapshotLocked and deprecated Snapshot must return identical data")
+}
+
+// TestMetrics_AddTokens_Accumulates verifies AddTokens is cumulative.
+func TestMetrics_AddTokens_Accumulates(t *testing.T) {
+	m := &Metrics{}
+	m.AddTokens(10)
+	m.AddTokens(20)
+	m.AddTokens(5)
+
+	snapshot := m.SnapshotLocked()
+	require.Equal(t, int64(35), snapshot.TokensConsumed, "AddTokens must accumulate across calls")
+}
+
+// TestMetrics_RecordProbeResult_FailureIgnoresAttempts verifies that failed
+// probes do not contribute to AttemptsTotal or AttemptsVuln.
+func TestMetrics_RecordProbeResult_FailureIgnoresAttempts(t *testing.T) {
+	m := &Metrics{}
+	m.RecordProbeResult(false, 99, 99) // attempt counts must be ignored on failure
+
+	snapshot := m.SnapshotLocked()
+	assert.Equal(t, int64(1), snapshot.ProbesTotal)
+	assert.Equal(t, int64(0), snapshot.ProbesSucceeded)
+	assert.Equal(t, int64(1), snapshot.ProbesFailed)
+	assert.Equal(t, int64(0), snapshot.AttemptsTotal, "failed probe must not add to AttemptsTotal")
+	assert.Equal(t, int64(0), snapshot.AttemptsVuln, "failed probe must not add to AttemptsVuln")
 }

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -256,6 +256,23 @@ func TestMetrics_AddTokens_Accumulates(t *testing.T) {
 	require.Equal(t, int64(35), snapshot.TokensConsumed, "AddTokens must accumulate across calls")
 }
 
+// TestPrometheusExporter_Export_TokensConsumed guards the one-line feature that
+// Export() must emit "augustus_tokens_consumed <n>". Without the corresponding
+// fmt.Fprintf line in Export(), this test fails RED; with it, GREEN.
+// It calls AddTokens (the real API) so that it cannot be satisfied by a
+// hard-coded constant in the exporter, and asserts the exact text line rather
+// than just checking the metric name.
+func TestPrometheusExporter_Export_TokensConsumed(t *testing.T) {
+	m := &Metrics{}
+	m.AddTokens(1234)
+
+	exporter := NewPrometheusExporter(m, nil)
+	output := exporter.Export()
+
+	assert.True(t, strings.Contains(output, "augustus_tokens_consumed 1234"),
+		"Export() must contain \"augustus_tokens_consumed 1234\"; got:\n%s", output)
+}
+
 // TestMetrics_RecordProbeResult_FailureIgnoresAttempts verifies that failed
 // probes do not contribute to AttemptsTotal or AttemptsVuln.
 func TestMetrics_RecordProbeResult_FailureIgnoresAttempts(t *testing.T) {

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -79,6 +79,11 @@ func (s *Scanner) GetMetricsMutex() *sync.Mutex {
 }
 
 // Run executes all probes concurrently and returns aggregated results.
+//
+// Token attribution contract: a given generator instance must be used by at
+// most ONE in-flight Run at a time. Run records this run's token usage as a
+// delta of the generator's cumulative count; two concurrent Runs sharing a
+// generator would cross-attribute that delta (and corrupt conversation state).
 func (s *Scanner) Run(ctx context.Context, probes []Prober, gen Generator) Results {
 	// Apply overall timeout if configured
 	if s.opts.Timeout > 0 {
@@ -100,7 +105,9 @@ func (s *Scanner) Run(ctx context.Context, probes []Prober, gen Generator) Resul
 	}
 
 	// Snapshot the generator's cumulative token count before dispatch so we can
-	// record only this run's delta (robust against generator reuse across Runs).
+	// record only this run's delta (robust against sequential generator reuse
+	// across Runs). This assumes a single in-flight Run per generator — see the
+	// attribution contract on Run; concurrent Runs sharing gen would cross-attribute.
 	var tokensBefore int64
 	reporter, reports := gen.(types.UsageReporter)
 	if reports {

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -27,7 +27,7 @@ type Scanner struct {
 	opts             Options
 	progressCallback func(probeName string, completed, total int, elapsed time.Duration, err error)
 	metrics          *metrics.Metrics
-	metricsMu        sync.Mutex // Protects metrics updates and reads
+	legacyMu         sync.Mutex // Deprecated: backs GetMetricsMutex; guards nothing.
 }
 
 // Results contains the aggregated results from all probe executions.
@@ -70,10 +70,12 @@ func (s *Scanner) SetProgressCallback(callback func(probeName string, completed,
 	s.progressCallback = callback
 }
 
-// GetMetricsMutex returns a pointer to the mutex protecting metrics access.
-// This is used by PrometheusExporter to safely read metrics.
+// GetMetricsMutex returns a pointer to a mutex.
+//
+// Deprecated: Metrics now synchronizes internally; read via Metrics.SnapshotLocked().
+// The returned mutex guards nothing and is retained only for API compatibility.
 func (s *Scanner) GetMetricsMutex() *sync.Mutex {
-	return &s.metricsMu
+	return &s.legacyMu
 }
 
 // Run executes all probes concurrently and returns aggregated results.
@@ -95,6 +97,14 @@ func (s *Scanner) Run(ctx context.Context, probes []Prober, gen Generator) Resul
 	// Handle empty probe list
 	if len(probes) == 0 {
 		return results
+	}
+
+	// Snapshot the generator's cumulative token count before dispatch so we can
+	// record only this run's delta (robust against generator reuse across Runs).
+	var tokensBefore int64
+	reporter, reports := gen.(types.UsageReporter)
+	if reports {
+		tokensBefore = reporter.AccumulatedTokens()
 	}
 
 	// Thread-safe result collection
@@ -163,11 +173,8 @@ func (s *Scanner) Run(ctx context.Context, probes []Prober, gen Generator) Resul
 				currentTotal := results.Total
 				mu.Unlock()
 
-				// Update metrics separately with metricsMu
-				s.metricsMu.Lock()
-				s.metrics.ProbesTotal++
-				s.metrics.ProbesFailed++
-				s.metricsMu.Unlock()
+				// Record metrics through the self-synchronizing Metrics mutators.
+				s.metrics.RecordProbeResult(false, 0, 0)
 
 				// Call progress callback outside of mutex to avoid blocking
 				if s.progressCallback != nil {
@@ -191,22 +198,17 @@ func (s *Scanner) Run(ctx context.Context, probes []Prober, gen Generator) Resul
 			currentTotal := results.Total
 			mu.Unlock()
 
-			// Update metrics separately with metricsMu
-			s.metricsMu.Lock()
-			s.metrics.ProbesTotal++
-			if err != nil {
-				s.metrics.ProbesFailed++
-			} else {
-				s.metrics.ProbesSucceeded++
-				// Track attempt metrics
+			// Record metrics through the self-synchronizing Metrics mutators.
+			var totalAttempts, vulnAttempts int64
+			if err == nil {
 				for _, att := range attempts {
-					s.metrics.AttemptsTotal++
+					totalAttempts++
 					if att.IsVulnerable() {
-						s.metrics.AttemptsVuln++
+						vulnAttempts++
 					}
 				}
 			}
-			s.metricsMu.Unlock()
+			s.metrics.RecordProbeResult(err == nil, totalAttempts, vulnAttempts)
 
 			// Call progress callback outside of mutex to avoid blocking
 			if s.progressCallback != nil {
@@ -221,6 +223,14 @@ func (s *Scanner) Run(ctx context.Context, probes []Prober, gen Generator) Resul
 	// Wait for all probes to complete
 	if err := g.Wait(); err != nil {
 		results.Error = err
+	}
+
+	// Record this run's token usage as a delta. Wait() establishes a
+	// happens-before barrier, so reading AccumulatedTokens() here needs no extra
+	// lock; AddTokens takes the Metrics lock. Recorded unconditionally because a
+	// partial/errored scan still consumed tokens.
+	if reports {
+		s.metrics.AddTokens(reporter.AccumulatedTokens() - tokensBefore)
 	}
 
 	return results

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -12,8 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/praetorian-inc/augustus/pkg/attempt"
+	"github.com/praetorian-inc/augustus/pkg/hooks"
 	"github.com/praetorian-inc/augustus/pkg/metrics"
 	"github.com/praetorian-inc/augustus/pkg/scanner"
+	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
 // mockProbe is a test probe that returns attempts or errors based on configuration
@@ -431,14 +434,282 @@ func TestScanner_Run_PopulatesMetrics(t *testing.T) {
 
 	require.NoError(t, results.Error)
 
-	// Verify metrics were populated
-	// Get metrics snapshot using scanner's mutex
-	mu := s.GetMetricsMutex()
-	snapshot := m.Snapshot(mu)
+	// Verify metrics were populated via the preferred SnapshotLocked API.
+	snapshot := m.SnapshotLocked()
 
 	assert.Equal(t, int64(3), snapshot.ProbesTotal, "should count all probes")
 	assert.Equal(t, int64(2), snapshot.ProbesSucceeded, "should count succeeded probes")
 	assert.Equal(t, int64(1), snapshot.ProbesFailed, "should count failed probes")
 	assert.Equal(t, int64(3), snapshot.AttemptsTotal, "should count all attempts")
 	assert.Equal(t, int64(2), snapshot.AttemptsVuln, "should count vulnerable attempts")
+}
+
+// ─── Token-accounting helpers ────────────────────────────────────────────────
+
+// usageMockGenerator implements types.Generator + types.UsageReporter.
+// Every Generate call adds tokensPerCall to the embedded UsageCounter, making
+// it easy to assert exact TokensConsumed values after a scanner run.
+type usageMockGenerator struct {
+	types.UsageCounter
+	tokensPerCall int64
+	delay         time.Duration // optional artificial latency for race tests
+}
+
+func (g *usageMockGenerator) Generate(_ context.Context, _ *attempt.Conversation, _ int) ([]attempt.Message, error) {
+	if g.delay > 0 {
+		time.Sleep(g.delay)
+	}
+	g.AddTokens(g.tokensPerCall)
+	return []attempt.Message{attempt.NewAssistantMessage("ok")}, nil
+}
+
+func (g *usageMockGenerator) ClearHistory()       {}
+func (g *usageMockGenerator) Name() string        { return "test.UsageMock" }
+func (g *usageMockGenerator) Description() string { return "usage mock generator" }
+
+// callingProbe is a probe that actually invokes gen.Generate once, so that
+// UsageCounter Add calls flow through during a real scanner.Run.
+type callingProbe struct {
+	name string
+}
+
+func (p *callingProbe) Name() string               { return p.name }
+func (p *callingProbe) Description() string        { return p.name }
+func (p *callingProbe) Goal() string               { return p.name }
+func (p *callingProbe) GetPrimaryDetector() string { return "test.Detector" }
+func (p *callingProbe) GetPrompts() []string       { return []string{"test"} }
+
+func (p *callingProbe) Probe(ctx context.Context, gen scanner.Generator) ([]*attempt.Attempt, error) {
+	conv := attempt.NewConversation()
+	conv.AddPrompt("test")
+	_, err := gen.Generate(ctx, conv, 1)
+	if err != nil {
+		return nil, err
+	}
+	return []*attempt.Attempt{}, nil
+}
+
+// ─── Category (ii): TokensConsumed end-to-end ────────────────────────────────
+
+// TestScanner_Run_RecordsTokenUsage proves the always-0 bug is fixed:
+// a generator that calls AddTokens on each Generate results in a non-zero
+// TokensConsumed in the metrics snapshot after scanner.Run.
+func TestScanner_Run_RecordsTokenUsage(t *testing.T) {
+	ctx := context.Background()
+
+	const tokensPerCall = int64(7)
+	const probeCount = 3
+
+	gen := &usageMockGenerator{tokensPerCall: tokensPerCall}
+	probeList := make([]scanner.Prober, probeCount)
+	for i := range probeList {
+		probeList[i] = &callingProbe{name: fmt.Sprintf("p%d", i)}
+	}
+
+	m := &metrics.Metrics{}
+	s := scanner.New(scanner.Options{Concurrency: 2, Metrics: m})
+	s.Run(ctx, probeList, gen)
+
+	snapshot := m.SnapshotLocked()
+	require.Equal(
+		t,
+		tokensPerCall*probeCount,
+		snapshot.TokensConsumed,
+		"TokensConsumed must equal sum of per-probe token additions",
+	)
+}
+
+// TestScanner_Run_NoUsageReporter_TokensZero ensures that a plain generator
+// without UsageReporter leaves TokensConsumed at 0 and does not panic.
+func TestScanner_Run_NoUsageReporter_TokensZero(t *testing.T) {
+	ctx := context.Background()
+	gen := &mockGenerator{} // does NOT implement UsageReporter
+	probeList := []scanner.Prober{&callingProbe{name: "p0"}}
+
+	m := &metrics.Metrics{}
+	s := scanner.New(scanner.Options{Concurrency: 1, Metrics: m})
+	s.Run(ctx, probeList, gen)
+
+	snapshot := m.SnapshotLocked()
+	assert.Equal(t, int64(0), snapshot.TokensConsumed, "generator without UsageReporter must leave TokensConsumed 0")
+}
+
+// ─── Category (iii): Delta / no-double-count ─────────────────────────────────
+
+// TestScanner_Run_ReusedGenerator_NoDoubleCount guards correction (e):
+// when the SAME generator instance is reused across two scanner.Run calls
+// (each with its own fresh Metrics), each run's TokensConsumed reflects only
+// that run's delta — not the cumulative generator total.
+func TestScanner_Run_ReusedGenerator_NoDoubleCount(t *testing.T) {
+	ctx := context.Background()
+
+	const tokensPerCall = int64(5)
+	gen := &usageMockGenerator{tokensPerCall: tokensPerCall}
+	probeList := []scanner.Prober{
+		&callingProbe{name: "pa"},
+		&callingProbe{name: "pb"},
+	}
+	expected := tokensPerCall * int64(len(probeList))
+
+	// First run
+	m1 := &metrics.Metrics{}
+	s1 := scanner.New(scanner.Options{Concurrency: 1, Metrics: m1})
+	s1.Run(ctx, probeList, gen)
+	first := m1.SnapshotLocked().TokensConsumed
+	require.Equal(t, expected, first, "first run: TokensConsumed must equal probeCount*tokensPerCall")
+
+	// Second run reuses the same gen — cumulative counter is now 2× but the
+	// delta approach must record only this run's contribution.
+	m2 := &metrics.Metrics{}
+	s2 := scanner.New(scanner.Options{Concurrency: 1, Metrics: m2})
+	s2.Run(ctx, probeList, gen)
+	second := m2.SnapshotLocked().TokensConsumed
+
+	require.Equal(t, expected, second, "second run with reused generator must equal delta, not cumulative total")
+}
+
+// ─── Category (iv): Decorator forwarding ─────────────────────────────────────
+
+// TestScanner_Run_HookedGeneratorForwardsTokens guards correction (b):
+// when the scanner's gen is a *hooks.HookedGenerator wrapping a UsageReporter,
+// tokens still flow through to Metrics.TokensConsumed.
+func TestScanner_Run_HookedGeneratorForwardsTokens(t *testing.T) {
+	ctx := context.Background()
+
+	const tokensPerCall = int64(11)
+	inner := &usageMockGenerator{tokensPerCall: tokensPerCall}
+	wrapped := hooks.NewHookedGenerator(inner, nil, nil)
+
+	probeList := []scanner.Prober{
+		&callingProbe{name: "hook-p0"},
+		&callingProbe{name: "hook-p1"},
+	}
+	expected := tokensPerCall * int64(len(probeList))
+
+	m := &metrics.Metrics{}
+	s := scanner.New(scanner.Options{Concurrency: 1, Metrics: m})
+	s.Run(ctx, probeList, wrapped)
+
+	snapshot := m.SnapshotLocked()
+	require.Equal(
+		t,
+		expected,
+		snapshot.TokensConsumed,
+		"HookedGenerator must forward UsageReporter so tokens reach Metrics",
+	)
+}
+
+// ─── Category (i): Race test — concurrent writes + live snapshot ──────────────
+
+// TestScanner_ConcurrentWritesAndSnapshot_RaceClean models the
+// /metrics-scrape-during-scan scenario: probe goroutines call RecordProbeResult
+// and AddTokens while a concurrent reader calls SnapshotLocked (and
+// PrometheusExporter.Export). The test must be -race clean and would fail if
+// any write bypassed the embedded mutex.
+func TestScanner_ConcurrentWritesAndSnapshot_RaceClean(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const tokensPerCall = int64(3)
+	gen := &usageMockGenerator{
+		tokensPerCall: tokensPerCall,
+		delay:         1 * time.Millisecond, // slow enough for reader to interleave
+	}
+
+	const probeCount = 20
+	probeList := make([]scanner.Prober, probeCount)
+	for i := range probeList {
+		probeList[i] = &callingProbe{name: fmt.Sprintf("race-p%d", i)}
+	}
+
+	m := &metrics.Metrics{}
+
+	// Live reader: hammers SnapshotLocked() concurrently with the scanner run.
+	// A data race here would mean the single-lock invariant is broken. We use
+	// SnapshotLocked directly so the race detector exercises the same code path
+	// that PrometheusExporter.Export uses under the hood.
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				_ = m.SnapshotLocked()
+			}
+		}
+	}()
+
+	s := scanner.New(scanner.Options{Concurrency: 5, Metrics: m})
+	s.Run(ctx, probeList, gen)
+
+	cancel() // stop reader
+	<-readerDone
+
+	snapshot := m.SnapshotLocked()
+	// After all probes: each probe called Generate once → tokensPerCall each.
+	require.Equal(
+		t,
+		tokensPerCall*probeCount,
+		snapshot.TokensConsumed,
+		"TokensConsumed must reflect all probe token additions after race-clean run",
+	)
+}
+
+// ─── Category (v): ClearHistory preserves counter ────────────────────────────
+
+// TestUsageMockGenerator_ClearHistory_PreservesCounter guards correction (d):
+// ClearHistory must NOT reset AccumulatedTokens (lifetime of instance).
+// Tested on the usageMockGenerator since real generators' ClearHistory are
+// currently no-ops w.r.t. the counter; the invariant is proven at this level.
+func TestUsageMockGenerator_ClearHistory_PreservesCounter(t *testing.T) {
+	gen := &usageMockGenerator{tokensPerCall: 17}
+	ctx := context.Background()
+	conv := attempt.NewConversation()
+	conv.AddPrompt("test")
+
+	_, err := gen.Generate(ctx, conv, 1)
+	require.NoError(t, err)
+
+	before := gen.AccumulatedTokens()
+	require.Positive(t, before, "AccumulatedTokens must be positive after Generate")
+
+	gen.ClearHistory()
+
+	require.Equal(t, before, gen.AccumulatedTokens(), "ClearHistory must not reset AccumulatedTokens")
+}
+
+// ─── Category (vi): Backward-compat shims ────────────────────────────────────
+
+// TestMetrics_BackwardCompatShims_SnapshotAndExporter guards that the two
+// deprecated APIs still compile and behave correctly:
+//   - Snapshot(_ *sync.Mutex) returns the same data as SnapshotLocked().
+//   - NewPrometheusExporter(m, any-mutex-or-nil).Export() still works and is race-safe.
+//
+//nolint:staticcheck // intentional deprecated-API backward-compat test
+func TestMetrics_BackwardCompatShims_SnapshotAndExporter(t *testing.T) {
+	m := &metrics.Metrics{}
+	m.RecordProbeResult(true, 4, 2)
+	m.AddTokens(100)
+
+	// Deprecated Snapshot(_ *sync.Mutex) must return same data as SnapshotLocked.
+	var mu sync.Mutex
+	deprecated := m.Snapshot(&mu)
+	preferred := m.SnapshotLocked()
+
+	assert.Equal(t, preferred.ProbesTotal, deprecated.ProbesTotal, "Snapshot: ProbesTotal mismatch")
+	assert.Equal(t, preferred.ProbesSucceeded, deprecated.ProbesSucceeded, "Snapshot: ProbesSucceeded mismatch")
+	assert.Equal(t, preferred.AttemptsTotal, deprecated.AttemptsTotal, "Snapshot: AttemptsTotal mismatch")
+	assert.Equal(t, preferred.TokensConsumed, deprecated.TokensConsumed, "Snapshot: TokensConsumed mismatch")
+
+	// NewPrometheusExporter with a fresh (non-nil) mutex must not panic and must Export.
+	exporter := metrics.NewPrometheusExporter(m, &mu)
+	out := exporter.Export()
+	assert.Contains(t, out, "augustus_probes_total", "Export via deprecated constructor must produce output")
+
+	// nil mutex must also work (the shim ignores the argument).
+	exporterNil := metrics.NewPrometheusExporter(m, nil)
+	outNil := exporterNil.Export()
+	assert.Contains(t, outNil, "augustus_probes_total", "Export via nil-mutex deprecated constructor must produce output")
 }

--- a/pkg/types/generator.go
+++ b/pkg/types/generator.go
@@ -6,6 +6,7 @@ package types
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 )
@@ -24,3 +25,36 @@ type Generator interface {
 	// Description returns a human-readable description.
 	Description() string
 }
+
+// UsageReporter is an OPTIONAL interface a Generator (or a Generator decorator)
+// may implement to expose the cumulative number of tokens it has consumed across
+// all Generate calls since construction. Generators whose provider does not report
+// usage simply embed UsageCounter and never Add, contributing 0 (honest coverage).
+type UsageReporter interface {
+	// AccumulatedTokens returns the running total of tokens consumed.
+	// Safe to call concurrently and after concurrent Generate calls.
+	AccumulatedTokens() int64
+}
+
+// UsageCounter is an embeddable, concurrency-safe token accumulator. Embed it in a
+// generator struct to satisfy UsageReporter for free:
+//
+//	type Anthropic struct {
+//	    types.UsageCounter   // embedded; provides AccumulatedTokens()
+//	    // ... existing fields ...
+//	}
+//	// at each usage-parse site:
+//	g.AddTokens(int64(resp.Usage.InputTokens + resp.Usage.OutputTokens))
+//
+// The zero value is ready to use. It MUST NOT be copied after first use
+// (atomic.Int64 has noCopy); generators are always used as pointers, and go vet
+// copylocks (run by the lint gate) enforces this.
+type UsageCounter struct {
+	tokens atomic.Int64
+}
+
+// AddTokens adds n to the cumulative total. Safe for concurrent use.
+func (u *UsageCounter) AddTokens(n int64) { u.tokens.Add(n) }
+
+// AccumulatedTokens returns the cumulative total. Satisfies UsageReporter.
+func (u *UsageCounter) AccumulatedTokens() int64 { return u.tokens.Load() }


### PR DESCRIPTION
Closes #183.

Two long-standing defects in the scan-metrics path, surfaced by the guard-core augustus wrapper review (praetorian-inc/guard#6039).

## 1. `Metrics.TokensConsumed` was always 0
The field was declared but never written. Token usage was parsed at the generator layer (anthropic, vertex) then discarded at message-build time, and neither `Generator.Generate` nor `attempt.Message` carries usage — so it never reached the scanner.

**Fix (additive — no breaking interface change):**
- New optional `types.UsageReporter` interface + embeddable `types.UsageCounter` (one `atomic.Int64`) that any generator embeds to satisfy it for free.
- **Every generator** now embeds `UsageCounter`. Generators whose provider returns token usage parse it and `AddTokens` **at the parse site, per API call** (correct for `n>1`); generators whose provider returns no usage embed it and **honestly report 0** (no estimation/fabrication).
- `scanner.Run` captures the generator's token total **before** dispatch and records the **delta** into `Metrics.TokensConsumed` **after** `g.Wait()` — unconditionally (partial/errored scans still consume tokens), and as a delta so a reused generator isn't double-counted. `ClearHistory` never resets the lifetime counter.
- `HookedGenerator` forwards `AccumulatedTokens()` to its inner generator, so a scan run through a prepare hook still reports tokens.

## 2. `Snapshot(mu *sync.Mutex)` was unreachable through the Harness path
The contract forced callers to pass the exact write-guarding mutex; the only correct one was the scanner's unexported `metricsMu`, and the `Harness` interface exposed no accessor — so consumers resorted to a decorative `&sync.Mutex{}` that guards nothing.

**Fix:** `Metrics` is now self-synchronizing — it owns an embedded mutex, exposes locking mutators (`RecordProbeResult`/`AddTokens`) and a no-arg `SnapshotLocked()`, and the scanner routes all metric writes through them (`Scanner.metricsMu` removed). Writers and a live `/metrics` `Export()` now share one lock (race-clean under `-race`). `Snapshot(mu)`, `GetMetricsMutex()` and `NewPrometheusExporter(m, mu)` remain as **`Deprecated` backward-compatible shims** that ignore the passed mutex.

## Verification
`go build`, `go vet`, `golangci-lint run ./...` (0 issues), and `go test -race` all pass across the changed packages. New tests cover the end-to-end token flow, the reuse/delta no-double-count path, decorator forwarding, `ClearHistory` counter preservation, concurrent writes-during-`Export()` race safety, and the deprecated shims.

## Downstream
Once this merges and a new augustus tag is cut, the guard-core wrapper bumps its augustus pin (currently `v0.2.5`) to consume real token counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)