### PR TITLE
ci: opt into org leaderboard metrics collection

### DIFF
--- a/.github/workflows/leaderboard-metrics.yml
+++ b/.github/workflows/leaderboard-metrics.yml
@@ -1,0 +1,16 @@
+name: Leaderboard Metrics
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: read
+  id-token: write
+
+jobs:
+  metrics:
+    uses: praetorian-inc/.github/.github/workflows/leaderboard-metrics.yml@main
+    with:
+      capability_map: '[{"path": ".", "name": "augustus"}]'


### PR DESCRIPTION
Opts this repo into the org-wide engineering leaderboard by calling the reusable workflow in `praetorian-inc/.github`. On every merged PR, per-author line stats are collected and sent to the Guard leaderboard ingestion queue (feeds the **Code** and **Assists** columns).

- The required `leaderboard` GitHub environment has already been created on this repo (no protection rules).
- The three org-level variables the workflow needs (`ENGINEER_EMAIL_MAP`, `LEADERBOARD_METRICS_ROLE_ARN`, `LEADERBOARD_METRICS_QUEUE_URL`) are visible to all org repos.
- No AWS changes needed: the OIDC trust policy keys on the reusable workflow ref, not the calling repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)