### PR TITLE
ci(release): repin go-release to v2.14.1 + reviewer-less release environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   release:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-release.yml@c5f6f98f1faf8f9ac6a870eced139b2509e08bfc  # v2.12.1
+    uses: praetorian-inc/public-workflows/.github/workflows/go-release.yml@33495156a75eaa4e8f97dd7f8c29c1d371e50688  # v2.14.1
     permissions:
       contents: write
       packages: write
@@ -17,6 +17,12 @@ jobs:
       attestations: write
     with:
       release-mode: auto-tag-from-main
+      # Reviewer-less environment satisfying the repo's OIDC sub-claim customization
+      # (include_claim_keys lists "environment": an environment-less job with
+      # id-token: write fails at job preparation). Do NOT add required reviewers:
+      # auto-tag mode releases on every main merge, and the tag is pushed before
+      # this gate — see the environment input docs in go-release.yml.
+      environment: release
     # Push the auto-tag as the praetorian-ci-version-bumper App so it can bypass
     # the org "Protected Version Tags" ruleset (creation-only bypass).
     secrets:


### PR DESCRIPTION
## Summary

Repins `go-release.yml` from v2.12.1 (c5f6f98) to **v2.14.1** (`33495156`, merge of https://github.com/praetorian-inc/public-workflows/pull/128) and passes the new optional `environment: release` input.

## Why

Repos with the Actions OIDC sub-claim customization `include_claim_keys: ["job_workflow_ref", "environment"]` cannot mint an OIDC token in an environment-less job — the `goreleaser` job (`id-token: write` for cosign keyless signing + provenance) fails at job preparation with "OIDC error: the claim 'environment' cannot be null or empty", zero steps run. This repo: currently on OIDC defaults (policy was reverted after the 2026-07-06T00:44Z failure, run 28760729468) — this PR future-proofs re-applying it.

A reviewer-less `release` environment has been created in repo settings (this PR's input references it). It is deliberately reviewer-less: auto-tag mode releases on every main merge, and the tag is pushed before the environment gate — see the `environment` input docs in go-release.yml v2.14.1.

## Pin-jump delta

The go-release.yml diff absorbed by this repin was reviewed in public-workflows PR #128: the `environment` input + goreleaser-job binding, cleanup hardened to `(failure() || cancelled())` (cancel/reject cleanup semantics probe-verified in runs 28800352986 / 28800438317 / 28800519582). No input-surface or behavioral change for this caller beyond the new environment.

Ticket: LAB-4607 (parent LAB-4605 / LAB-4604)

🤖 Generated with [Claude Code](https://claude.com/claude-code)