### PR TITLE
fix(scan): scope detectors per probe to kill cross-probe verdict false positives

### DIFF
--- a/cmd/augustus/scan.go
+++ b/cmd/augustus/scan.go
@@ -382,34 +382,49 @@ func createDetectors(detectorNames []string, probeList []probes.Prober, yamlCfg 
 	return detectorList, nil
 }
 
-// buildProbeDetectorMap builds a map of probe name → per-probe detector list
-// for probes that implement ProbeDetectorConfig (non-empty detector_config) or
-// ProbeSecondaryDetectors (non-empty secondary_detectors list), or both.
+// buildProbeDetectorMap builds a map of probe name → per-probe detector list.
 //
-// Primary detector logic (ProbeDetectorConfig): the probe's detector_config is
-// merged on top of the global YAML config for the primary detector, and the
-// resulting instance is placed first in the slice.
+// The returned map scopes each probe's detector set — and therefore which
+// detectors land in attempt.DetectorResults and feed the MAX-based verdict in
+// attempt.GetEffectiveScores — to detectors that are actually relevant to that
+// probe (its declared primary + declared secondaries). This prevents unrelated
+// detectors from leaking into a probe's set and falsely marking its attempts
+// vulnerable (the #125 → #131 cross-probe false positive).
 //
-// Secondary detector logic (ProbeSecondaryDetectors): for each secondary entry,
-// a fresh detector instance is created by merging the secondary's Config on top
-// of the global YAML config for that detector name, and appended to the slice.
+// In a multi-probe run without an explicit --detector, createDetectors builds
+// detectorList as the UNION of every probe's primary detector, and the verdict
+// is MAX-over-all-of-DetectorResults. If every probe ran that union, an unrelated
+// high-scoring detector (e.g. goodside.Glitch) would MAX into the verdict of a
+// probe whose own detector scored 0.0. Scoping each probe's set at the source
+// (here) is the fix, and — unlike a verdict-layer patch — it also means fewer
+// detectors run.
 //
-// Probes with neither interface (or with empty configs and no secondaries) are
-// absent from the returned map; their callers fall back to the shared detectorList.
-func buildProbeDetectorMap(probeList []probes.Prober, detectorList []detectors.Detector, yamlCfg *config.Config) (map[string][]detectors.Detector, error) {
+// detectorsExplicit distinguishes the two modes:
+//
+//   - detectorsExplicit == false (auto-collected union): detectorList is the
+//     union of every probe's primary and is NOT a deliberate user request. Each
+//     probe gets a scoped set = its own declared primary + its declared
+//     secondaries; the union is NOT appended. EVERY probe with a known primary
+//     receives an override so the harness never falls back to the shared union.
+//
+//   - detectorsExplicit == true (user passed --detector / --detectors-glob):
+//     running those exact detectors against every probe is a deliberate request,
+//     so only probes that declare detector_config or secondary_detectors get an
+//     override (probe primary + user detectors deduped + secondaries); every
+//     other probe falls back to the user-requested detectorList in the harness,
+//     exactly as before.
+//
+// Per-detector config: a probe's detector_config (ProbeDetectorConfig) is merged
+// on top of the global YAML config for its primary. Each declared secondary
+// (ProbeSecondaryDetectors) is created by merging the secondary's Config on top
+// of the global YAML config for that detector name.
+func buildProbeDetectorMap(probeList []probes.Prober, detectorList []detectors.Detector, yamlCfg *config.Config, detectorsExplicit bool) (map[string][]detectors.Detector, error) {
 	overrides := make(map[string][]detectors.Detector)
 
 	for _, probe := range probeList {
 		pdc, hasPrimary := probe.(types.ProbeDetectorConfig)
 		psd, hasSecondary := probe.(types.ProbeSecondaryDetectors)
 
-		// Neither interface implemented → no override needed.
-		if !hasPrimary && !hasSecondary {
-			continue
-		}
-
-		// ProbeDetectorConfig present but empty config AND no secondaries → skip
-		// (same early-exit as before, but now gated on both being absent/empty).
 		var probeCfg map[string]any
 		if hasPrimary {
 			probeCfg = pdc.GetDetectorConfig()
@@ -418,18 +433,25 @@ func buildProbeDetectorMap(probeList []probes.Prober, detectorList []detectors.D
 		if hasSecondary {
 			secondaries = psd.GetSecondaryDetectors()
 		}
-		if len(probeCfg) == 0 && len(secondaries) == 0 {
+
+		// In explicit mode we preserve the original behavior: only probes that
+		// declare a non-empty detector_config or secondary_detectors get an
+		// override; everything else falls back to the user-requested detectorList.
+		//
+		// In auto-collected (union) mode we ALWAYS emit a scoped override so the
+		// harness never falls back to the union — that fallback is the leak.
+		if detectorsExplicit && len(probeCfg) == 0 && len(secondaries) == 0 {
 			continue
 		}
 
 		probeDetectors := make([]detectors.Detector, 0, len(detectorList)+len(secondaries))
 
 		// --- Primary detectors ---
-		// Build primary list unconditionally: probe's declared primary first (hoisted),
-		// then any user-selected detectors deduped. Always run primaries — even when
-		// probeCfg is empty, the secondary must NOT replace the primary detector list.
-		// When probeCfg is empty, mergeCfgs(baseCfg, probeCfg) returns baseCfg unchanged,
-		// so the primary gets the global YAML config as if it were not in the override map.
+		// The probe's declared primary is always placed first (hoisted). In
+		// explicit mode the user-requested detectorList is then appended (deduped)
+		// so those detectors still run. In auto-collected mode detectorList is the
+		// union of all probes' primaries and is intentionally NOT appended — only
+		// this probe's own primary belongs in its set.
 		{
 			seen := make(map[string]bool, len(detectorList))
 			var primaryName string
@@ -441,10 +463,12 @@ func buildProbeDetectorMap(probeList []probes.Prober, detectorList []detectors.D
 					seen[primary] = true
 				}
 			}
-			for _, d := range detectorList {
-				if !seen[d.Name()] {
-					primaryNames = append(primaryNames, d.Name())
-					seen[d.Name()] = true
+			if detectorsExplicit {
+				for _, d := range detectorList {
+					if !seen[d.Name()] {
+						primaryNames = append(primaryNames, d.Name())
+						seen[d.Name()] = true
+					}
 				}
 			}
 
@@ -684,10 +708,21 @@ func runScanResolved(ctx context.Context, cfg *scanConfig, yamlCfg *config.Confi
 		return err
 	}
 
-	// Build per-probe detector overrides for probes with detector_config blocks.
-	// Called before buff wrapping so that the raw probes' ProbeDetectorConfig
-	// interface is accessible; BuffedProber wrappers do not forward the interface.
-	probeDetectorOverrides, err := buildProbeDetectorMap(probeList, detectorList, yamlCfg)
+	// Build per-probe detector overrides so each probe's attempts run only that
+	// probe's own detectors (primary + declared secondaries), scoping the verdict
+	// MAX and preventing cross-probe false positives. Called before buff wrapping
+	// so that the raw probes' ProbeDetectorConfig / ProbeSecondaryDetectors /
+	// ProbeMetadata interfaces are accessible; BuffedProber wrappers do not forward
+	// them (BuffedProber.Name() returns the inner name, so the map key still matches
+	// a.Probe at scoring time).
+	//
+	// detectorsExplicit is true only when the user explicitly requested detectors
+	// via --detector / --detectors-glob. When false, detectorList is the
+	// auto-collected union of every probe's primary and must be scoped per-probe to
+	// avoid leaking unrelated detectors into each probe's verdict (see
+	// buildProbeDetectorMap for the #125 → #131 regression details).
+	detectorsExplicit := len(cfg.detectorNames) > 0
+	probeDetectorOverrides, err := buildProbeDetectorMap(probeList, detectorList, yamlCfg, detectorsExplicit)
 	if err != nil {
 		return fmt.Errorf("building per-probe detector map: %w", err)
 	}

--- a/cmd/augustus/scan.go
+++ b/cmd/augustus/scan.go
@@ -749,6 +749,11 @@ func runScanResolved(ctx context.Context, cfg *scanConfig, yamlCfg *config.Confi
 	if len(probeDetectorOverrides) > 0 {
 		harnessConfig["probe_detector_overrides"] = probeDetectorOverrides
 	}
+	// Tell the harness which detector-selection mode is in effect so its
+	// per-attempt fallback is correct: in explicit mode a probe without an
+	// override runs the user-requested detectorList; in auto mode it must be
+	// scoped to its own primary (never the union). See harnesses.SelectProbeDetectors.
+	harnessConfig["detectors_explicit"] = detectorsExplicit
 	harness, err := harnesses.Create(cfg.harnessName, harnessConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create harness %s: %w", cfg.harnessName, err)

--- a/cmd/augustus/scan_test.go
+++ b/cmd/augustus/scan_test.go
@@ -1034,6 +1034,89 @@ func TestScan_HarnessRegression_NoCrossProbeFP(t *testing.T) {
 	}
 }
 
+// A probe that declares no detector at all — GetPrimaryDetector() == "".
+const regressionNoPrimaryProbeYAML = `
+id: test.NoPrimaryProbe
+info:
+  name: No Primary Probe
+  author: test
+  description: declares no detector; must not fall back to the cross-probe union
+  goal: test
+  severity: high
+prompts:
+  - "Hello."
+`
+
+// TestScan_HarnessRegression_PrimaryLessProbeNotFlipped covers the reviewer
+// finding (Codex/CodeRabbit/Claude/Gemini): a probe that gets no override entry
+// must NOT fall back to the shared union in auto mode, or the cross-probe false
+// positive returns for that class. A probe with no declared primary is scored by
+// nothing (its own primary is empty) rather than by an unrelated union detector.
+func TestScan_HarnessRegression_PrimaryLessProbeNotFlipped(t *testing.T) {
+	// Realistic multi-probe run: two normal probes (which populate the override
+	// map) plus one probe that declares no detector. The union detectorList
+	// therefore contains an unrelated high-scoring detector (always.Fail); the
+	// primary-less probe must NOT fall back to that union.
+	safeProbe := newTemplateProbeFromYAML(t, regressionSafeProbeYAML)
+	vulnProbe := newTemplateProbeFromYAML(t, regressionVulnProbeYAML)
+	noPrimary := newTemplateProbeFromYAML(t, regressionNoPrimaryProbeYAML)
+
+	passDet, err := detectors.Create("always.Pass", registry.Config{})
+	require.NoError(t, err)
+	failDet, err := detectors.Create("always.Fail", registry.Config{})
+	require.NoError(t, err)
+	detectorList := []detectors.Detector{passDet, failDet}
+
+	overrides, err := buildProbeDetectorMap(
+		[]probes.Prober{safeProbe, vulnProbe, noPrimary},
+		detectorList,
+		nil,
+		false,
+	)
+	require.NoError(t, err)
+	// Normal probes get scoped entries; the primary-less probe does not — so the
+	// map is non-empty (a scoped scan) and the missing probe must be scoped to
+	// its own (empty) primary, not the union.
+	require.Contains(t, overrides, "test.SafeProbe")
+	require.Contains(t, overrides, "test.VulnProbe")
+	require.NotContains(t, overrides, "test.NoPrimaryProbe")
+
+	gen, err := generators.Create("test.Lipsum", registry.Config{})
+	require.NoError(t, err)
+
+	for _, harnessName := range []string{"probewise.Probewise", "agentwise.Agentwise", "batch.Batch"} {
+		t.Run(harnessName, func(t *testing.T) {
+			capEval := &harnessCaptureEval{}
+			// detectors_explicit omitted → auto mode (the leak-prone path).
+			h, err := harnesses.Create(harnessName, registry.Config{
+				"probe_detector_overrides": overrides,
+			})
+			require.NoError(t, err)
+
+			err = h.Run(context.Background(), gen, []probes.Prober{safeProbe, vulnProbe, noPrimary}, detectorList, capEval)
+			require.NoError(t, err)
+			require.Len(t, capEval.attempts, 3)
+
+			var noPrimaryAttempt *attempt.Attempt
+			for _, a := range capEval.attempts {
+				if a.Probe == "test.NoPrimaryProbe" {
+					noPrimaryAttempt = a
+				}
+			}
+			require.NotNil(t, noPrimaryAttempt, "primary-less probe attempt must be present")
+
+			// Scored by nothing (its own primary is empty) — must NOT be flipped
+			// VULN by the unrelated always.Fail detector in the union.
+			for _, s := range noPrimaryAttempt.GetEffectiveScores() {
+				assert.LessOrEqual(t, s, 0.5,
+					"%s: primary-less probe must not be flagged by the unrelated union detector", harnessName)
+			}
+			assert.False(t, noPrimaryAttempt.IsVulnerable(),
+				"%s: primary-less probe must not be marked vulnerable via the union fallback", harnessName)
+		})
+	}
+}
+
 // TestBuildProbeDetectorMap_InvalidRegexFailsAtLoad verifies G6: an invalid
 // regex in forbidden_patterns causes buildProbeDetectorMap to return an error
 // containing both the detector name and the probe name. This ensures schema

--- a/cmd/augustus/scan_test.go
+++ b/cmd/augustus/scan_test.go
@@ -805,7 +805,7 @@ prompts:
 	sharedDet, err := detectors.Create("agent.ArgumentExfiltration", registry.Config{})
 	require.NoError(t, err)
 
-	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, yamlCfg)
+	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, yamlCfg, true)
 	require.NoError(t, err)
 
 	// The probe has a non-empty detector_config, so it must appear in the map.
@@ -883,9 +883,155 @@ prompts:
 		[]probes.Prober{probeA, probeB},
 		[]detectors.Detector{sharedDet},
 		nil,
+		true, // explicit mode: probes without detector_config/secondaries stay absent
 	)
 	require.NoError(t, err)
-	assert.Len(t, overrides, 0, "probes without detector_config (or with empty map) must be absent from override map")
+	assert.Len(t, overrides, 0, "in explicit mode, probes without detector_config (or with empty map) must be absent from override map")
+}
+
+// yaml helpers for the cross-probe regression tests below.
+const regressionSafeProbeYAML = `
+id: test.SafeProbe
+info:
+  name: Safe Probe
+  author: test
+  description: primary detector always scores 0.0
+  goal: test
+  detector: always.Pass
+  severity: high
+prompts:
+  - "Hello."
+`
+
+const regressionVulnProbeYAML = `
+id: test.VulnProbe
+info:
+  name: Vuln Probe
+  author: test
+  description: primary detector always scores 1.0
+  goal: test
+  detector: always.Fail
+  severity: high
+prompts:
+  - "Hello."
+`
+
+// TestBuildProbeDetectorMap_AutoCollected_NoUnrelatedDetectorLeak is the
+// regression test for the #125 → #131 cross-probe false positive at the dispatch
+// layer. In auto-collected mode (no explicit --detector), detectorList is the
+// union of every probe's primary. Each probe's override MUST contain only its
+// own primary (+ declared secondaries); the union must NOT leak in, so an
+// unrelated high-scoring detector cannot MAX into a probe's verdict.
+//
+// It drives the real verdict path (buildProbeDetectorMap → ApplyDetectors →
+// GetEffectiveScores) and asserts a probe whose own detector scores 0.0 is NOT
+// flagged vulnerable by an unrelated union detector that scores 1.0. It fails
+// against the pre-fix union-append behavior.
+func TestBuildProbeDetectorMap_AutoCollected_NoUnrelatedDetectorLeak(t *testing.T) {
+	safeProbe := newTemplateProbeFromYAML(t, regressionSafeProbeYAML)
+	vulnProbe := newTemplateProbeFromYAML(t, regressionVulnProbeYAML)
+
+	// detectorList is the auto-collected union of both probes' primaries — exactly
+	// what createDetectors builds in a multi-probe run without --detector.
+	passDet, err := detectors.Create("always.Pass", registry.Config{})
+	require.NoError(t, err)
+	failDet, err := detectors.Create("always.Fail", registry.Config{})
+	require.NoError(t, err)
+	detectorList := []detectors.Detector{passDet, failDet}
+
+	// Auto-collected mode (detectorsExplicit == false): every probe must get a
+	// scoped override = its own primary only.
+	overrides, err := buildProbeDetectorMap(
+		[]probes.Prober{safeProbe, vulnProbe},
+		detectorList,
+		nil,
+		false,
+	)
+	require.NoError(t, err)
+
+	// Each probe's set contains ONLY its own primary — no union leak.
+	require.Contains(t, overrides, "test.SafeProbe")
+	require.Len(t, overrides["test.SafeProbe"], 1, "safe probe must run only its own primary (no union leak)")
+	assert.Equal(t, "always.Pass", overrides["test.SafeProbe"][0].Name())
+
+	require.Contains(t, overrides, "test.VulnProbe")
+	require.Len(t, overrides["test.VulnProbe"], 1, "vuln probe must run only its own primary (no union leak)")
+	assert.Equal(t, "always.Fail", overrides["test.VulnProbe"][0].Name())
+
+	// Drive the real verdict path for the safe probe: with scoping it is scored
+	// only by always.Pass → verdict 0.0 (SAFE). Before the fix the union ran and
+	// always.Fail would MAX the verdict to 1.0 (the false positive).
+	ctx := context.Background()
+	a := attempt.New("Hello.")
+	a.Probe = "test.SafeProbe"
+	a.AddOutput("some benign response")
+	require.NoError(t, harnesses.ApplyDetectors(ctx, a, overrides["test.SafeProbe"], harnesses.SkipOnError))
+
+	scores := a.GetEffectiveScores()
+	require.NotEmpty(t, scores)
+	assert.Equal(t, 0.0, scores[0],
+		"safe probe verdict must stay 0.0 — the unrelated always.Fail detector must not leak into its set")
+}
+
+// TestScan_HarnessRegression_NoCrossProbeFP proves the scoping holds end-to-end
+// through every harness that runs detectors — probewise, agentwise AND batch. A
+// probe whose own detector scores 0.0 must stay SAFE even though an unrelated
+// detector in the run scores 1.0. agentwise and batch previously ignored the
+// per-probe map entirely, so this covers the case the prior dispatch-only fix
+// (a7c8ee3) missed.
+func TestScan_HarnessRegression_NoCrossProbeFP(t *testing.T) {
+	safeProbe := newTemplateProbeFromYAML(t, regressionSafeProbeYAML)
+	vulnProbe := newTemplateProbeFromYAML(t, regressionVulnProbeYAML)
+
+	passDet, err := detectors.Create("always.Pass", registry.Config{})
+	require.NoError(t, err)
+	failDet, err := detectors.Create("always.Fail", registry.Config{})
+	require.NoError(t, err)
+	detectorList := []detectors.Detector{passDet, failDet}
+
+	overrides, err := buildProbeDetectorMap(
+		[]probes.Prober{safeProbe, vulnProbe},
+		detectorList,
+		nil,
+		false,
+	)
+	require.NoError(t, err)
+
+	gen, err := generators.Create("test.Lipsum", registry.Config{})
+	require.NoError(t, err)
+
+	for _, harnessName := range []string{"probewise.Probewise", "agentwise.Agentwise", "batch.Batch"} {
+		t.Run(harnessName, func(t *testing.T) {
+			capEval := &harnessCaptureEval{}
+			h, err := harnesses.Create(harnessName, registry.Config{
+				"probe_detector_overrides": overrides,
+			})
+			require.NoError(t, err)
+
+			err = h.Run(context.Background(), gen, []probes.Prober{safeProbe, vulnProbe}, detectorList, capEval)
+			require.NoError(t, err)
+			require.Len(t, capEval.attempts, 2, "both probes must produce an attempt")
+
+			byProbe := make(map[string]*attempt.Attempt, 2)
+			for _, a := range capEval.attempts {
+				byProbe[a.Probe] = a
+			}
+
+			safe := byProbe["test.SafeProbe"]
+			require.NotNil(t, safe, "safe probe attempt must be present")
+			safeScores := safe.GetEffectiveScores()
+			require.NotEmpty(t, safeScores)
+			assert.Equal(t, 0.0, safeScores[0],
+				"%s: safe probe must NOT be flipped VULN by the unrelated always.Fail detector", harnessName)
+
+			vuln := byProbe["test.VulnProbe"]
+			require.NotNil(t, vuln, "vuln probe attempt must be present")
+			vulnScores := vuln.GetEffectiveScores()
+			require.NotEmpty(t, vulnScores)
+			assert.Equal(t, 1.0, vulnScores[0],
+				"%s: vuln probe must still be flagged VULN by its own detector", harnessName)
+		})
+	}
 }
 
 // TestBuildProbeDetectorMap_InvalidRegexFailsAtLoad verifies G6: an invalid
@@ -913,7 +1059,7 @@ prompts:
 	sharedDet, err := detectors.Create("agent.ArgumentExfiltration", registry.Config{})
 	require.NoError(t, err)
 
-	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil)
+	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil, true)
 	require.Error(t, err, "invalid regex in detector_config should cause error at load time")
 	assert.Nil(t, overrides, "override map should be nil on error")
 	assert.Contains(t, err.Error(), "agent.ArgumentExfiltration", "error should name the detector")
@@ -971,7 +1117,7 @@ prompts:
 		sharedDet, err := detectors.Create("agent.ArgumentExfiltration", registry.Config{})
 		require.NoError(t, err)
 
-		overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil)
+		overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil, true)
 		require.NoError(t, err)
 		require.Len(t, overrides, 1, "probe with override must appear in map")
 
@@ -1002,7 +1148,7 @@ prompts:
 		sharedDet, err := detectors.Create("agent.ArgumentExfiltration", registry.Config{})
 		require.NoError(t, err)
 
-		overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil)
+		overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil, true)
 		require.NoError(t, err)
 
 		// Build harness with overrides wired in.
@@ -1067,7 +1213,7 @@ prompts:
 	sharedDet, err := detectors.Create("agent.ToolManipulation", registry.Config{})
 	require.NoError(t, err)
 
-	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil)
+	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil, true)
 	require.NoError(t, err)
 	require.Len(t, overrides, 1, "probe with secondary_detectors must appear in override map")
 
@@ -1106,7 +1252,7 @@ prompts:
 	sharedDet, err := detectors.Create("agent.ToolManipulation", registry.Config{})
 	require.NoError(t, err)
 
-	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil)
+	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil, true)
 	require.NoError(t, err)
 	require.Contains(t, overrides, "test.SecondaryOnlyPrimaryRuns")
 
@@ -1144,7 +1290,7 @@ prompts:
 	sharedDet, err := detectors.Create("agent.ToolManipulation", registry.Config{})
 	require.NoError(t, err)
 
-	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil)
+	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil, true)
 	require.NoError(t, err)
 	require.Len(t, overrides, 1)
 
@@ -1180,7 +1326,7 @@ prompts:
 	sharedDet, err := detectors.Create("agent.ToolManipulation", registry.Config{})
 	require.NoError(t, err)
 
-	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil)
+	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil, true)
 	require.NoError(t, err)
 	// Must be present even though no detector_config
 	require.Contains(t, overrides, "test.SecondaryOnlyProbe",
@@ -1221,7 +1367,7 @@ prompts:
 	sharedDet, err := detectors.Create("agent.ArgumentExfiltration", registry.Config{})
 	require.NoError(t, err)
 
-	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, yamlCfg)
+	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, yamlCfg, true)
 	require.NoError(t, err)
 	require.Contains(t, overrides, "test.SecondaryMerge")
 	// P0-B fix: primary (ToolManipulation) is now at [0]; secondary (ArgumentExfiltration) at [2].
@@ -1272,7 +1418,7 @@ prompts:
 	sharedDet, err := detectors.Create("agent.ToolManipulation", registry.Config{})
 	require.NoError(t, err)
 
-	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil)
+	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil, true)
 	require.NoError(t, err)
 
 	require.Contains(t, overrides, "test.H3Compound", "compound probe must enter override map")
@@ -1335,7 +1481,7 @@ prompts:
 	require.NoError(t, err)
 	detectorList := []detectors.Detector{detA, detB, detC}
 
-	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, detectorList, nil)
+	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, detectorList, nil, true)
 	require.NoError(t, err)
 
 	detList, ok := overrides["test.MetadataPrimaryProbe"]
@@ -1387,7 +1533,7 @@ prompts:
 	require.NoError(t, err)
 	detectorList := []detectors.Detector{detFirst, detPrimary}
 
-	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, detectorList, nil)
+	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, detectorList, nil, true)
 	require.NoError(t, err)
 
 	detList, ok := overrides["test.HoistPrimaryProbe"]
@@ -1429,7 +1575,7 @@ prompts:
 	sharedDet, err := detectors.Create("agent.ToolManipulation", registry.Config{})
 	require.NoError(t, err)
 
-	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil)
+	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil, true)
 	require.NoError(t, err)
 
 	// The override map must be empty: both interfaces present but both return empty
@@ -1477,7 +1623,7 @@ prompts:
 	chainLengthDet, err := detectors.Create("agent.ChainLength", registry.Config{})
 	require.NoError(t, err)
 
-	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{chainLengthDet}, nil)
+	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{chainLengthDet}, nil, true)
 	require.NoError(t, err)
 	require.Contains(t, overrides, "test.PrimaryNotInDetectorList")
 
@@ -1536,7 +1682,7 @@ prompts:
 	sharedDet, err := detectors.Create("agent.ToolManipulation", registry.Config{})
 	require.NoError(t, err)
 
-	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, yamlCfg)
+	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, yamlCfg, true)
 	require.NoError(t, err)
 	require.Contains(t, overrides, "test.OperatorConfigFlows")
 
@@ -1588,7 +1734,7 @@ prompts:
 	sharedDet, err := detectors.Create("agent.ToolManipulation", registry.Config{})
 	require.NoError(t, err)
 
-	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil)
+	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, []detectors.Detector{sharedDet}, nil, true)
 	require.NoError(t, err)
 
 	require.Contains(t, overrides, "test.H4Compound")
@@ -1692,7 +1838,7 @@ prompts:
 	sentinelDet := &cfgCaptureDet{name: sentinelName}
 	detectorList := []detectors.Detector{primaryDet, sentinelDet}
 
-	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, detectorList, nil)
+	overrides, err := buildProbeDetectorMap([]probes.Prober{probe}, detectorList, nil, true)
 	require.NoError(t, err)
 
 	detList, ok := overrides["test.ProbeCfgLeakProbe"]
@@ -1760,7 +1906,7 @@ prompts:
 		noMetaProbe := newTemplateProbeFromYAML(t, noMetaYAML)
 		noPrimaryDet := &cfgCaptureDet{name: noPrimarySentinelName}
 
-		_, err := buildProbeDetectorMap([]probes.Prober{noMetaProbe}, []detectors.Detector{noPrimaryDet}, nil)
+		_, err := buildProbeDetectorMap([]probes.Prober{noMetaProbe}, []detectors.Detector{noPrimaryDet}, nil, true)
 		require.NoError(t, err)
 
 		// noPrimaryReceivedCfg is set when buildProbeDetectorMap creates noPrimarySentinelName.

--- a/cmd/augustus/scan_test.go
+++ b/cmd/augustus/scan_test.go
@@ -997,7 +997,10 @@ func TestScan_HarnessRegression_NoCrossProbeFP(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	gen, err := generators.Create("test.Lipsum", registry.Config{})
+	// test.Single is stateless (concurrency-safe); the concurrent harnesses
+	// (probewise/batch) run probes in parallel, so a generator with a shared
+	// mutable RNG (e.g. test.Lipsum) would data-race under `go test -race`.
+	gen, err := generators.Create("test.Single", registry.Config{})
 	require.NoError(t, err)
 
 	for _, harnessName := range []string{"probewise.Probewise", "agentwise.Agentwise", "batch.Batch"} {
@@ -1081,7 +1084,10 @@ func TestScan_HarnessRegression_PrimaryLessProbeNotFlipped(t *testing.T) {
 	require.Contains(t, overrides, "test.VulnProbe")
 	require.NotContains(t, overrides, "test.NoPrimaryProbe")
 
-	gen, err := generators.Create("test.Lipsum", registry.Config{})
+	// test.Single is stateless (concurrency-safe); the concurrent harnesses
+	// (probewise/batch) run probes in parallel, so a generator with a shared
+	// mutable RNG (e.g. test.Lipsum) would data-race under `go test -race`.
+	gen, err := generators.Create("test.Single", registry.Config{})
 	require.NoError(t, err)
 
 	for _, harnessName := range []string{"probewise.Probewise", "agentwise.Agentwise", "batch.Batch"} {

--- a/internal/harnesses/agentwise/agentwise.go
+++ b/internal/harnesses/agentwise/agentwise.go
@@ -42,6 +42,11 @@ type AgentConfig struct {
 // Agentwise implements a harness that filters probes based on agent capabilities.
 type Agentwise struct {
 	config AgentConfig
+	// probeDetectorOverrides scopes detectors per probe (primary + declared
+	// secondaries) so an attempt is scored only by its own probe's detectors,
+	// keeping unrelated detectors out of the MAX-based verdict. Keyed by probe
+	// name; empty/absent entry falls back to the shared detectorList.
+	probeDetectorOverrides map[string][]detectors.Detector
 }
 
 // New creates a new agentwise harness with the given configuration.
@@ -173,8 +178,16 @@ func (a *Agentwise) Run(
 				att.Generator = gen.Name()
 			}
 
+			// Select detector list: per-probe override takes precedence so an
+			// attempt is scored only by its own probe's detectors, keeping
+			// unrelated detectors out of the verdict.
+			activeDetectors := detectorList
+			if perProbe, ok := a.probeDetectorOverrides[att.Probe]; ok {
+				activeDetectors = perProbe
+			}
+
 			// Run detectors using shared logic (FailOnError for strict propagation)
-			if err := harnesses.ApplyDetectors(ctx, att, detectorList, harnesses.FailOnError); err != nil {
+			if err := harnesses.ApplyDetectors(ctx, att, activeDetectors, harnesses.FailOnError); err != nil {
 				return err
 			}
 		}
@@ -207,7 +220,16 @@ func init() {
 			config.ToolList = toolList
 		}
 
-		return New(config), nil
+		h := New(config)
+
+		// Extract per-probe detector overrides if provided
+		if overrides, ok := cfg["probe_detector_overrides"].(map[string][]detectors.Detector); ok {
+			h.probeDetectorOverrides = overrides
+		} else if _, exists := cfg["probe_detector_overrides"]; exists {
+			slog.Warn("agentwise: key has unexpected type, ignoring", "key", "probe_detector_overrides", "type", fmt.Sprintf("%T", cfg["probe_detector_overrides"]))
+		}
+
+		return h, nil
 	})
 }
 

--- a/internal/harnesses/agentwise/agentwise.go
+++ b/internal/harnesses/agentwise/agentwise.go
@@ -44,9 +44,12 @@ type Agentwise struct {
 	config AgentConfig
 	// probeDetectorOverrides scopes detectors per probe (primary + declared
 	// secondaries) so an attempt is scored only by its own probe's detectors,
-	// keeping unrelated detectors out of the MAX-based verdict. Keyed by probe
-	// name; empty/absent entry falls back to the shared detectorList.
+	// keeping unrelated detectors out of the MAX-based verdict. Keyed by probe name.
 	probeDetectorOverrides map[string][]detectors.Detector
+	// detectorsExplicit controls the per-attempt fallback when a probe has no
+	// override entry: explicit → the shared detectorList; auto → the probe's own
+	// primary only (never the cross-probe union).
+	detectorsExplicit bool
 }
 
 // New creates a new agentwise harness with the given configuration.
@@ -178,13 +181,11 @@ func (a *Agentwise) Run(
 				att.Generator = gen.Name()
 			}
 
-			// Select detector list: per-probe override takes precedence so an
-			// attempt is scored only by its own probe's detectors, keeping
-			// unrelated detectors out of the verdict.
-			activeDetectors := detectorList
-			if perProbe, ok := a.probeDetectorOverrides[att.Probe]; ok {
-				activeDetectors = perProbe
-			}
+			// Select detector list: per-probe override takes precedence;
+			// otherwise scope to the probe's own primary (auto mode) or the
+			// shared list (explicit mode) — never the cross-probe union in
+			// auto mode.
+			activeDetectors := harnesses.SelectProbeDetectors(att, detectorList, a.probeDetectorOverrides, a.detectorsExplicit)
 
 			// Run detectors using shared logic (FailOnError for strict propagation)
 			if err := harnesses.ApplyDetectors(ctx, att, activeDetectors, harnesses.FailOnError); err != nil {
@@ -227,6 +228,11 @@ func init() {
 			h.probeDetectorOverrides = overrides
 		} else if _, exists := cfg["probe_detector_overrides"]; exists {
 			slog.Warn("agentwise: key has unexpected type, ignoring", "key", "probe_detector_overrides", "type", fmt.Sprintf("%T", cfg["probe_detector_overrides"]))
+		}
+
+		// Extract detector-selection mode (controls the per-attempt fallback).
+		if explicit, ok := cfg["detectors_explicit"].(bool); ok {
+			h.detectorsExplicit = explicit
 		}
 
 		return h, nil

--- a/internal/harnesses/batch/batch.go
+++ b/internal/harnesses/batch/batch.go
@@ -31,6 +31,11 @@ var (
 type Batch struct {
 	concurrency int
 	timeout     time.Duration
+	// probeDetectorOverrides scopes detectors per probe (primary + declared
+	// secondaries) so an attempt is scored only by its own probe's detectors,
+	// keeping unrelated detectors out of the MAX-based verdict. Keyed by probe
+	// name; empty/absent entry falls back to the shared detectorList.
+	probeDetectorOverrides map[string][]detectors.Detector
 }
 
 // New creates a new batch harness from configuration.
@@ -54,6 +59,13 @@ func New(cfg registry.Config) (*Batch, error) {
 		}
 	} else if timeoutDur, ok := cfg["timeout"].(time.Duration); ok {
 		b.timeout = timeoutDur
+	}
+
+	// Optional: per-probe detector overrides
+	if overrides, ok := cfg["probe_detector_overrides"].(map[string][]detectors.Detector); ok {
+		b.probeDetectorOverrides = overrides
+	} else if _, exists := cfg["probe_detector_overrides"]; exists {
+		slog.Warn("batch: key has unexpected type, ignoring", "key", "probe_detector_overrides", "type", fmt.Sprintf("%T", cfg["probe_detector_overrides"]))
 	}
 
 	return b, nil
@@ -137,8 +149,16 @@ func (b *Batch) Run(
 					a.Generator = gen.Name()
 				}
 
+				// Select detector list: per-probe override takes precedence so an
+				// attempt is scored only by its own probe's detectors, keeping
+				// unrelated detectors out of the verdict.
+				activeDetectors := detectorList
+				if perProbe, ok := b.probeDetectorOverrides[a.Probe]; ok {
+					activeDetectors = perProbe
+				}
+
 				// Run detectors using shared logic (FailOnError routes to errs channel)
-				if err := harnesses.ApplyDetectors(ctx, a, detectorList, harnesses.FailOnError); err != nil {
+				if err := harnesses.ApplyDetectors(ctx, a, activeDetectors, harnesses.FailOnError); err != nil {
 					errs <- err
 					return
 				}

--- a/internal/harnesses/batch/batch.go
+++ b/internal/harnesses/batch/batch.go
@@ -33,9 +33,12 @@ type Batch struct {
 	timeout     time.Duration
 	// probeDetectorOverrides scopes detectors per probe (primary + declared
 	// secondaries) so an attempt is scored only by its own probe's detectors,
-	// keeping unrelated detectors out of the MAX-based verdict. Keyed by probe
-	// name; empty/absent entry falls back to the shared detectorList.
+	// keeping unrelated detectors out of the MAX-based verdict. Keyed by probe name.
 	probeDetectorOverrides map[string][]detectors.Detector
+	// detectorsExplicit controls the per-attempt fallback when a probe has no
+	// override entry: explicit → the shared detectorList; auto → the probe's own
+	// primary only (never the cross-probe union).
+	detectorsExplicit bool
 }
 
 // New creates a new batch harness from configuration.
@@ -66,6 +69,11 @@ func New(cfg registry.Config) (*Batch, error) {
 		b.probeDetectorOverrides = overrides
 	} else if _, exists := cfg["probe_detector_overrides"]; exists {
 		slog.Warn("batch: key has unexpected type, ignoring", "key", "probe_detector_overrides", "type", fmt.Sprintf("%T", cfg["probe_detector_overrides"]))
+	}
+
+	// Optional: detector-selection mode (controls the per-attempt fallback).
+	if explicit, ok := cfg["detectors_explicit"].(bool); ok {
+		b.detectorsExplicit = explicit
 	}
 
 	return b, nil
@@ -149,13 +157,11 @@ func (b *Batch) Run(
 					a.Generator = gen.Name()
 				}
 
-				// Select detector list: per-probe override takes precedence so an
-				// attempt is scored only by its own probe's detectors, keeping
-				// unrelated detectors out of the verdict.
-				activeDetectors := detectorList
-				if perProbe, ok := b.probeDetectorOverrides[a.Probe]; ok {
-					activeDetectors = perProbe
-				}
+				// Select detector list: per-probe override takes precedence;
+				// otherwise scope to the probe's own primary (auto mode) or the
+				// shared list (explicit mode) — never the cross-probe union in
+				// auto mode.
+				activeDetectors := harnesses.SelectProbeDetectors(a, detectorList, b.probeDetectorOverrides, b.detectorsExplicit)
 
 				// Run detectors using shared logic (FailOnError routes to errs channel)
 				if err := harnesses.ApplyDetectors(ctx, a, activeDetectors, harnesses.FailOnError); err != nil {

--- a/internal/harnesses/probewise/probewise.go
+++ b/internal/harnesses/probewise/probewise.go
@@ -41,6 +41,10 @@ type Probewise struct {
 	opts                   *scanner.Options
 	onAttemptProcessed     func(*attempt.Attempt)
 	probeDetectorOverrides map[string][]detectors.Detector
+	// detectorsExplicit is true when the user passed --detector/--detectors-glob.
+	// It controls the per-attempt fallback when a probe has no override entry:
+	// explicit → the shared detectorList; auto → the probe's own primary only.
+	detectorsExplicit bool
 }
 
 // New creates a new probewise harness.
@@ -174,13 +178,10 @@ func (p *Probewise) Run(
 			a.Generator = gen.Name()
 		}
 
-		// Select detector list: per-probe override takes precedence when present.
-		activeDetectors := detectorList
-		if len(p.probeDetectorOverrides) > 0 {
-			if perProbe, ok := p.probeDetectorOverrides[a.Probe]; ok {
-				activeDetectors = perProbe
-			}
-		}
+		// Select detector list: per-probe override takes precedence; otherwise
+		// scope to the probe's own primary (auto mode) or the shared list
+		// (explicit mode) — never the cross-probe union in auto mode.
+		activeDetectors := harnesses.SelectProbeDetectors(a, detectorList, p.probeDetectorOverrides, p.detectorsExplicit)
 
 		// Run detectors using shared logic (SkipOnError for partial results)
 		if err := harnesses.ApplyDetectors(evalCtx, a, activeDetectors, harnesses.SkipOnError); err != nil {
@@ -227,6 +228,10 @@ func init() {
 			p.probeDetectorOverrides = overrides
 		} else if _, exists := cfg["probe_detector_overrides"]; exists {
 			slog.Warn("probewise: key has unexpected type, ignoring", "key", "probe_detector_overrides", "type", fmt.Sprintf("%T", cfg["probe_detector_overrides"]))
+		}
+		// Extract detector-selection mode (controls the per-attempt fallback).
+		if explicit, ok := cfg["detectors_explicit"].(bool); ok {
+			p.detectorsExplicit = explicit
 		}
 		return p, nil
 	})

--- a/pkg/harnesses/detection.go
+++ b/pkg/harnesses/detection.go
@@ -51,6 +51,12 @@ func SelectProbeDetectors(
 		return detectorList
 	}
 	if a.Detector == "" {
+		// A scoped scan is in effect but this attempt carries neither a mapped
+		// Probe nor a primary detector — it cannot be scored by anything of its
+		// own. Fail loud (do not silently fall back to the union) so the
+		// unscoreable attempt is visible rather than a quiet "safe" verdict.
+		slog.Warn("no scoped detector for attempt; scoring nothing (not falling back to the detector union)",
+			"probe", a.Probe)
 		return nil
 	}
 	scoped := make([]detectors.Detector, 0, 1)

--- a/pkg/harnesses/detection.go
+++ b/pkg/harnesses/detection.go
@@ -10,6 +10,58 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/detectors"
 )
 
+// SelectProbeDetectors returns the detector set to run for an attempt, scoping
+// it to the probe so unrelated detectors cannot leak into the MAX-based verdict.
+//
+// Precedence:
+//  1. The probe's own override entry (primary + declared secondaries), when present.
+//  2. Explicit mode (user passed --detector/--detectors-glob): the shared
+//     detectorList — running those exact detectors against every probe is a
+//     deliberate request.
+//  3. Auto-collected mode with NO per-probe map at all (a direct/library caller
+//     that handed the harness a curated detectorList): run that list as given.
+//  4. Auto-collected mode WITH a per-probe map, but this attempt is missing from
+//     it (a primary-less probe, or an attempt whose Probe was never set): scope
+//     to the probe's OWN primary via a.Detector. It must NEVER fall back to the
+//     full detectorList here — in a scoped scan that list is the union of all
+//     probes' primaries, and reusing it reintroduces the cross-probe false
+//     positive this scoping exists to prevent.
+//
+// Keying the auto-mode fallback on a.Detector (which the probe sets at attempt
+// creation, independent of a.Probe) also covers attempts whose Probe value is
+// missing or mismatched. When a.Detector is empty (a probe that declares no
+// detector at all), nothing is run: an unscoreable probe yields no verdict
+// rather than a bag-driven false positive.
+func SelectProbeDetectors(
+	a *attempt.Attempt,
+	detectorList []detectors.Detector,
+	overrides map[string][]detectors.Detector,
+	detectorsExplicit bool,
+) []detectors.Detector {
+	if perProbe, ok := overrides[a.Probe]; ok {
+		return perProbe
+	}
+	if detectorsExplicit {
+		return detectorList
+	}
+	// Auto mode. Only scope when a per-probe map was actually built (a scoped
+	// scan); with no map there is no scoping information, so honor the caller's
+	// detectorList.
+	if len(overrides) == 0 {
+		return detectorList
+	}
+	if a.Detector == "" {
+		return nil
+	}
+	scoped := make([]detectors.Detector, 0, 1)
+	for _, d := range detectorList {
+		if d.Name() == a.Detector {
+			scoped = append(scoped, d)
+		}
+	}
+	return scoped
+}
+
 // DetectorErrorBehavior defines how detector errors should be handled.
 type DetectorErrorBehavior int
 

--- a/pkg/harnesses/detection_test.go
+++ b/pkg/harnesses/detection_test.go
@@ -35,6 +35,68 @@ func (m *mockDetector) Description() string {
 	return m.description
 }
 
+func TestSelectProbeDetectors(t *testing.T) {
+	primary := &mockDetector{name: "probe.Primary"}
+	secondary := &mockDetector{name: "probe.Secondary"}
+	unrelated := &mockDetector{name: "other.Primary"}
+
+	// detectorList is the auto-collected union of both probes' primaries.
+	detectorList := []detectors.Detector{primary, unrelated}
+	overrides := map[string][]detectors.Detector{
+		"test.Probe": {primary, secondary},
+	}
+
+	names := func(ds []detectors.Detector) []string {
+		out := make([]string, len(ds))
+		for i, d := range ds {
+			out[i] = d.Name()
+		}
+		return out
+	}
+
+	t.Run("override present → returns the probe's scoped set", func(t *testing.T) {
+		a := &attempt.Attempt{Probe: "test.Probe", Detector: "probe.Primary"}
+		got := SelectProbeDetectors(a, detectorList, overrides, false)
+		assert.Equal(t, []string{"probe.Primary", "probe.Secondary"}, names(got))
+	})
+
+	t.Run("explicit mode, no override → returns full detectorList", func(t *testing.T) {
+		a := &attempt.Attempt{Probe: "unmapped.Probe", Detector: "probe.Primary"}
+		got := SelectProbeDetectors(a, detectorList, overrides, true)
+		assert.Equal(t, []string{"probe.Primary", "other.Primary"}, names(got))
+	})
+
+	t.Run("auto mode, no override → scopes to the probe's own primary, NOT the union", func(t *testing.T) {
+		// The unrelated detector must not leak in — this is the cross-probe FP fix.
+		a := &attempt.Attempt{Probe: "unmapped.Probe", Detector: "probe.Primary"}
+		got := SelectProbeDetectors(a, detectorList, overrides, false)
+		assert.Equal(t, []string{"probe.Primary"}, names(got),
+			"auto-mode fallback must be the probe's own primary, never the union")
+	})
+
+	t.Run("auto mode, missing Probe value → still scopes by a.Detector", func(t *testing.T) {
+		// Covers attempts returned before Probe is set: the map lookup misses,
+		// but scoping by a.Detector keeps the union out.
+		a := &attempt.Attempt{Probe: "", Detector: "other.Primary"}
+		got := SelectProbeDetectors(a, detectorList, overrides, false)
+		assert.Equal(t, []string{"other.Primary"}, names(got))
+	})
+
+	t.Run("auto mode, empty primary → runs nothing (no bag-driven false positive)", func(t *testing.T) {
+		a := &attempt.Attempt{Probe: "noprimary.Probe", Detector: ""}
+		got := SelectProbeDetectors(a, detectorList, overrides, false)
+		assert.Empty(t, got, "a probe with no declared detector must not fall back to the union")
+	})
+
+	t.Run("auto mode, NO per-probe map → runs the caller's detectorList", func(t *testing.T) {
+		// Direct/library callers that hand the harness a curated list and no
+		// overrides must still get that list (backward compatible).
+		a := &attempt.Attempt{Probe: "any.Probe", Detector: "probe.Primary"}
+		got := SelectProbeDetectors(a, detectorList, nil, false)
+		assert.Equal(t, []string{"probe.Primary", "other.Primary"}, names(got))
+	})
+}
+
 func TestApplyDetectors_SingleDetector(t *testing.T) {
 	ctx := context.Background()
 	a := attempt.New("test prompt")


### PR DESCRIPTION
## Problem

In a multi-probe run, an attempt could be marked **VULNERABLE by a detector unrelated to the probe that produced it** (cross-probe false positive).

`attempt.GetEffectiveScores()` computes the verdict as the element-wise **MAX over every entry in `DetectorResults`**. But in a multi-probe run, `createDetectors` builds `detectorList` as the **union of every probe's primary detector**, and every attempt was scored by all of them. An unrelated high-scoring detector (e.g. `goodside.Glitch` firing on a BOLA probe's benign output) then MAX'd into the verdict.

This is the **#125 → #131 regression**: #125 pinned the verdict to the probe's own detector; #131 replaced that with MAX-over-all-of-`DetectorResults` (so declared secondaries can raise a verdict) and re-armed the false positive. It has recurred multiple times.

## Fix — scope detectors per probe

Make the per-probe detector map authoritative and universal so each probe's attempts run **only that probe's own detectors** (primary + declared secondaries). With the bag scoped, `GetEffectiveScores`' MAX is correct as-is, declared secondaries still count, and fewer detectors run.

- `buildProbeDetectorMap` gains a `detectorsExplicit` flag:
  - **auto-collected mode** (no `--detector`): every probe gets a scoped set = its own primary + declared secondaries; the union is **not** appended.
  - **explicit mode** (`--detector`/`--detectors-glob`): preserved unchanged — primary + user-requested detectors (deduped) + secondaries.
- **`batch` and `agentwise` now consume `probe_detector_overrides`** like `probewise` already did. They previously ignored it entirely — which is why the prior dispatch-only attempt reached only `probewise` and the bug kept returning for agent/tool probes (which run under `agentwise`).

## Tests

- Existing `buildProbeDetectorMap` tests migrated to `detectorsExplicit == true` (the mode whose append/dedup/hoist semantics they assert).
- `TestBuildProbeDetectorMap_AutoCollected_NoUnrelatedDetectorLeak` — drives the real verdict path; a probe scoring `0.0` is not flagged by an unrelated union detector scoring `1.0`.
- `TestScan_HarnessRegression_NoCrossProbeFP` — proves the scoping end-to-end through **probewise, agentwise AND batch**.

`make build`, `gofmt`, `go vet`, and full `go test ./...` all pass.

## Tradeoff

Drops (unrealized, never-surfaced) cross-probe detector coverage — no report renders incidental hits today, so there is no realized loss. If wanted later, it returns as an explicit opt-in feature. Full rationale in `docs/plans/2026-07-03-detector-role-verdict-design.md`.

Refs LAB-4645

🤖 Generated with [Claude Code](https://claude.com/claude-code)
