### PR TITLE
chore: leaderboard-metrics E2E verify (no-op)

### DIFF
--- a/.github/workflows/leaderboard-metrics.yml
+++ b/.github/workflows/leaderboard-metrics.yml
@@ -14,3 +14,4 @@ jobs:
     uses: praetorian-inc/public-workflows/.github/workflows/leaderboard-metrics.yml@main
     with:
       capability_map: '[{"path": ".", "name": "augustus"}]'
+# e2e-verify: trust hotfix confirmation run  (no-op comment; safe to remove)


### PR DESCRIPTION
Trivial no-op comment to trigger the leaderboard-metrics caller on merge and confirm the OIDC trust hotfix (repoint to public-workflows + repository_owner anchor) delivers to SQS. Safe to revert.