### PR TITLE
Remove CODEOWNERS to stop automatic reviewer assignment

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,0 @@
-# Augustus Code Owners
-# These users/teams will be automatically requested for review on PRs
-
-* @praetorian-inc/praetorian-guard-core-team


### PR DESCRIPTION
## What

Removes the `CODEOWNERS` file entirely.

## Why

The file's only rule was a repo-wide wildcard:

```
* @praetorian-inc/praetorian-guard-core-team
```

This auto-requested the core team as reviewers on **every** PR. Removing the file disables automatic reviewer assignment repo-wide.

## Note

This is a repo-wide governance change — it affects automatic reviewer assignment for all contributors, not just one person. @praetorian-inc/praetorian-guard-core-team should confirm they're okay dropping automatic review requests before merge. If the intent is only to change ownership scope (rather than remove it), an alternative would be scoping ownership to specific paths instead of deleting the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)