### PR TITLE
fix(anthropic): make temperature opt-in so newest models work (LAB-4691)

### DIFF
--- a/internal/generators/anthropic/anthropic.go
+++ b/internal/generators/anthropic/anthropic.go
@@ -32,11 +32,10 @@ func init() {
 
 // Default configuration values matching litellm patterns.
 const (
-	defaultMaxTokens   = 150
-	defaultTemperature = 0.7
-	defaultAPIVersion  = "2023-06-01"
-	defaultBaseURL     = "https://api.anthropic.com/v1"
-	defaultTimeout     = 90 * time.Second
+	defaultMaxTokens  = 150
+	defaultAPIVersion = "2023-06-01"
+	defaultBaseURL    = "https://api.anthropic.com/v1"
+	defaultTimeout    = 90 * time.Second
 )
 
 // Anthropic is a generator that wraps the Anthropic Messages API.
@@ -48,8 +47,9 @@ type Anthropic struct {
 	apiVersion string
 	model      string
 
-	// Configuration parameters
-	temperature   float64
+	// Configuration parameters. temperature is nil when unset so it is omitted
+	// from the request (see Config.Temperature).
+	temperature   *float64
 	maxTokens     int
 	topP          float64
 	topK          int
@@ -117,7 +117,7 @@ type messageRequest struct {
 	MaxTokens     int                  `json:"max_tokens"`
 	Messages      []Message            `json:"messages"`
 	System        string               `json:"system,omitempty"`
-	Temperature   float64              `json:"temperature,omitempty"`
+	Temperature   *float64             `json:"temperature,omitempty"`
 	TopP          float64              `json:"top_p,omitempty"`
 	TopK          int                  `json:"top_k,omitempty"`
 	StopSequences []string             `json:"stop_sequences,omitempty"`

--- a/internal/generators/anthropic/anthropic_test.go
+++ b/internal/generators/anthropic/anthropic_test.go
@@ -697,7 +697,7 @@ func TestAnthropicGenerator_DefaultTemperature(t *testing.T) {
 		"model":    "claude-3-opus-20240229",
 		"api_key":  "test-key",
 		"base_url": server.URL,
-		// No temperature specified - should use default
+		// No temperature specified.
 	})
 	require.NoError(t, err)
 
@@ -707,10 +707,38 @@ func TestAnthropicGenerator_DefaultTemperature(t *testing.T) {
 	_, err = g.Generate(context.Background(), conv, 1)
 	require.NoError(t, err)
 
-	// Default temperature should match litellm pattern (0.7)
-	if temp, ok := receivedRequest["temperature"].(float64); ok {
-		assert.InDelta(t, 0.7, temp, 0.01)
-	}
+	// Temperature is opt-in: when unset it must be omitted entirely rather than
+	// defaulted, so the request works against models that reject the field (e.g.
+	// claude-sonnet-5 returns "temperature is deprecated for this model").
+	_, present := receivedRequest["temperature"]
+	assert.False(t, present, "temperature must be absent from the request when not configured")
+}
+
+func TestAnthropicGenerator_ExplicitZeroTemperature(t *testing.T) {
+	var receivedRequest map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&receivedRequest)
+		_ = json.NewEncoder(w).Encode(mockAnthropicResponse("Response"))
+	}))
+	defer server.Close()
+
+	g, err := NewAnthropic(registry.Config{
+		"model":       "claude-3-opus-20240229",
+		"api_key":     "test-key",
+		"base_url":    server.URL,
+		"temperature": 0.0, // explicit 0 must be honored, not treated as unset
+	})
+	require.NoError(t, err)
+
+	conv := attempt.NewConversation()
+	conv.AddPrompt("test")
+
+	_, err = g.Generate(context.Background(), conv, 1)
+	require.NoError(t, err)
+
+	temp, present := receivedRequest["temperature"]
+	require.True(t, present, "explicitly configured temperature=0 must be sent")
+	assert.Equal(t, float64(0), temp)
 }
 
 func TestAnthropicGenerator_AnthropicVersion(t *testing.T) {

--- a/internal/generators/anthropic/config.go
+++ b/internal/generators/anthropic/config.go
@@ -62,12 +62,17 @@ func ConfigFromMap(m registry.Config) (Config, error) {
 	// Optional parameters
 	cfg.BaseURL = registry.GetString(m, "base_url", cfg.BaseURL)
 	cfg.APIVersion = registry.GetString(m, "api_version", cfg.APIVersion)
-	// Temperature is opt-in: only set when the key is present, so an absent key
-	// leaves it nil (unsent) rather than defaulting. JSON/YAML numbers decode to
-	// float64; an int is accepted for hand-built maps.
-	if _, ok := m["temperature"]; ok {
-		temp := registry.GetFloat64(m, "temperature", 0)
-		cfg.Temperature = &temp
+	// Temperature is opt-in and type-safe: set the pointer only when the key
+	// holds an actual number (float64 from JSON/YAML, int from a hand-built map).
+	// A missing key OR a malformed value (e.g. a string like "0.5") leaves it nil
+	// (unset -> omitted from the request) rather than silently coercing to 0,
+	// which would force unexpectedly deterministic generation. Mirrors ollama.
+	switch v := m["temperature"].(type) {
+	case float64:
+		cfg.Temperature = &v
+	case int:
+		f := float64(v)
+		cfg.Temperature = &f
 	}
 	cfg.MaxTokens = registry.GetInt(m, "max_tokens", cfg.MaxTokens)
 	cfg.TopP = registry.GetFloat64(m, "top_p", cfg.TopP)

--- a/internal/generators/anthropic/config.go
+++ b/internal/generators/anthropic/config.go
@@ -12,8 +12,16 @@ type Config struct {
 	Model  string
 	APIKey string
 
-	// Optional with defaults
-	Temperature   float64
+	// Optional with defaults.
+	//
+	// Temperature is a pointer so "unset" (nil) is distinct from an explicit 0:
+	// when nil the field is omitted from the request entirely, rather than
+	// injecting a default the operator never asked for. This matters because the
+	// newest Anthropic models (e.g. claude-sonnet-5, claude-opus-4-x) reject the
+	// `temperature` field outright ("temperature is deprecated for this model"),
+	// so a hardcoded default would make them unusable out of the box. Mirrors the
+	// ollama generator's pointer handling.
+	Temperature   *float64
 	MaxTokens     int
 	TopP          float64
 	TopK          int
@@ -25,10 +33,11 @@ type Config struct {
 // DefaultConfig returns a Config with sensible defaults.
 func DefaultConfig() Config {
 	return Config{
-		Temperature: defaultTemperature,
-		MaxTokens:   defaultMaxTokens,
-		APIVersion:  defaultAPIVersion,
-		BaseURL:     defaultBaseURL,
+		// Temperature intentionally left nil (unset): only sent when the operator
+		// explicitly configures it. See the Config.Temperature doc comment.
+		MaxTokens:  defaultMaxTokens,
+		APIVersion: defaultAPIVersion,
+		BaseURL:    defaultBaseURL,
 	}
 }
 
@@ -53,7 +62,13 @@ func ConfigFromMap(m registry.Config) (Config, error) {
 	// Optional parameters
 	cfg.BaseURL = registry.GetString(m, "base_url", cfg.BaseURL)
 	cfg.APIVersion = registry.GetString(m, "api_version", cfg.APIVersion)
-	cfg.Temperature = registry.GetFloat64(m, "temperature", cfg.Temperature)
+	// Temperature is opt-in: only set when the key is present, so an absent key
+	// leaves it nil (unsent) rather than defaulting. JSON/YAML numbers decode to
+	// float64; an int is accepted for hand-built maps.
+	if _, ok := m["temperature"]; ok {
+		temp := registry.GetFloat64(m, "temperature", 0)
+		cfg.Temperature = &temp
+	}
 	cfg.MaxTokens = registry.GetInt(m, "max_tokens", cfg.MaxTokens)
 	cfg.TopP = registry.GetFloat64(m, "top_p", cfg.TopP)
 	cfg.TopK = registry.GetInt(m, "top_k", cfg.TopK)
@@ -84,10 +99,12 @@ func WithAPIKey(key string) Option {
 	}
 }
 
-// WithTemperature sets the sampling temperature.
+// WithTemperature sets the sampling temperature. Calling it marks temperature
+// as explicitly set (including 0); leaving it uncalled keeps temperature unset,
+// so the field is omitted from the request.
 func WithTemperature(temp float64) Option {
 	return func(c *Config) {
-		c.Temperature = temp
+		c.Temperature = &temp
 	}
 }
 
@@ -137,6 +154,10 @@ func WithAPIVersion(version string) Option {
 // This prevents accidental credential leakage in logs or error messages.
 func (c Config) String() string {
 	maskedKey := registry.MaskAPIKey(c.APIKey)
-	return fmt.Sprintf("Config{Model=%s, APIKey=%s, Temperature=%.2f, MaxTokens=%d}",
-		c.Model, maskedKey, c.Temperature, c.MaxTokens)
+	temp := "unset"
+	if c.Temperature != nil {
+		temp = fmt.Sprintf("%.2f", *c.Temperature)
+	}
+	return fmt.Sprintf("Config{Model=%s, APIKey=%s, Temperature=%s, MaxTokens=%d}",
+		c.Model, maskedKey, temp, c.MaxTokens)
 }

--- a/internal/generators/anthropic/config_test.go
+++ b/internal/generators/anthropic/config_test.go
@@ -12,7 +12,7 @@ import (
 func TestAnthropicConfigDefaults(t *testing.T) {
 	cfg := DefaultConfig()
 
-	assert.Equal(t, float64(0.7), cfg.Temperature)
+	assert.Nil(t, cfg.Temperature) // opt-in: unset by default, omitted from the request
 	assert.Equal(t, 150, cfg.MaxTokens)
 	assert.Equal(t, "2023-06-01", cfg.APIVersion)
 	assert.Equal(t, "https://api.anthropic.com/v1", cfg.BaseURL)
@@ -38,7 +38,8 @@ func TestAnthropicConfigFromMap(t *testing.T) {
 
 	assert.Equal(t, "claude-3-opus-20240229", cfg.Model)
 	assert.Equal(t, "sk-ant-test", cfg.APIKey)
-	assert.Equal(t, float64(0.5), cfg.Temperature)
+	require.NotNil(t, cfg.Temperature)
+	assert.Equal(t, float64(0.5), *cfg.Temperature)
 	assert.Equal(t, 300, cfg.MaxTokens)
 	assert.Equal(t, float64(0.9), cfg.TopP)
 	assert.Equal(t, 50, cfg.TopK)
@@ -82,7 +83,8 @@ func TestAnthropicConfigFunctionalOptions(t *testing.T) {
 
 	assert.Equal(t, "claude-3-opus-20240229", cfg.Model)
 	assert.Equal(t, "sk-ant-test", cfg.APIKey)
-	assert.Equal(t, float64(0.3), cfg.Temperature)
+	require.NotNil(t, cfg.Temperature)
+	assert.Equal(t, float64(0.3), *cfg.Temperature)
 	assert.Equal(t, 500, cfg.MaxTokens)
 	assert.Equal(t, float64(0.95), cfg.TopP)
 	assert.Equal(t, 100, cfg.TopK)

--- a/internal/generators/anthropic/config_test.go
+++ b/internal/generators/anthropic/config_test.go
@@ -56,6 +56,55 @@ func TestAnthropicConfigFromMapMissingModel(t *testing.T) {
 	assert.Contains(t, err.Error(), "model")
 }
 
+func TestAnthropicConfigFromMap_TemperatureTypeSafety(t *testing.T) {
+	base := registry.Config{
+		"model":   "claude-3-opus-20240229",
+		"api_key": "sk-ant-test",
+	}
+
+	t.Run("string value leaves temperature unset", func(t *testing.T) {
+		m := registry.Config{"model": base["model"], "api_key": base["api_key"], "temperature": "0.5"}
+
+		cfg, err := ConfigFromMap(m)
+		require.NoError(t, err)
+		assert.Nil(t, cfg.Temperature)
+	})
+
+	t.Run("bool value leaves temperature unset", func(t *testing.T) {
+		m := registry.Config{"model": base["model"], "api_key": base["api_key"], "temperature": true}
+
+		cfg, err := ConfigFromMap(m)
+		require.NoError(t, err)
+		assert.Nil(t, cfg.Temperature)
+	})
+
+	t.Run("missing key leaves temperature unset", func(t *testing.T) {
+		m := registry.Config{"model": base["model"], "api_key": base["api_key"]}
+
+		cfg, err := ConfigFromMap(m)
+		require.NoError(t, err)
+		assert.Nil(t, cfg.Temperature)
+	})
+
+	t.Run("int value sets temperature", func(t *testing.T) {
+		m := registry.Config{"model": base["model"], "api_key": base["api_key"], "temperature": 1}
+
+		cfg, err := ConfigFromMap(m)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.Temperature)
+		assert.Equal(t, 1.0, *cfg.Temperature)
+	})
+
+	t.Run("explicit zero float64 sets temperature", func(t *testing.T) {
+		m := registry.Config{"model": base["model"], "api_key": base["api_key"], "temperature": float64(0.0)}
+
+		cfg, err := ConfigFromMap(m)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.Temperature)
+		assert.Equal(t, 0.0, *cfg.Temperature)
+	})
+}
+
 func TestAnthropicConfigFromMapEnvAPIKey(t *testing.T) {
 	// Set env var for test
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-env-test")


### PR DESCRIPTION
Linear: LAB-4691

## Summary

The Anthropic generator hardcoded a default `temperature: 0.7` and sent it on **every** request. The newest Claude models — `claude-sonnet-5`, `claude-opus-4-x` — reject the field outright:

```
anthropic: bad request (invalid_request_error): `temperature` is deprecated for this model.
```

So the generator could not target the current Claude generation at all without a manual `-c '{"temperature":0}'` workaround (which only worked because `omitempty` dropped the zero).

## Fix

Make `temperature` **opt-in** by switching `Config.Temperature` and the request wire field to `*float64`, mirroring the existing `ollama` generator:

- **nil (unset)** → field omitted from the request → works against every model, including those that reject `temperature`.
- **explicitly configured** (via `-c '{"temperature":…}'`, config file, or `WithTemperature`) → sent as-is, **including an explicit `0`** — which the previous `float64` + `omitempty` encoding could not represent (it conflated "unset" with "0").

## Behavior change

A scan that does **not** set temperature no longer injects `0.7`; the provider's own default applies. This is the intended correction — the scanner should not inject a sampling parameter the operator never asked for, and injecting one made the newest models unusable.

## Tests

- `TestAnthropicConfigDefaults` — temperature is `nil` by default.
- `TestAnthropicGenerator_DefaultTemperature` — rewritten to assert the field is **absent** from the request when unset.
- `TestAnthropicGenerator_ExplicitZeroTemperature` — **new**: explicit `temperature: 0` is honored and sent.
- Config-from-map / options tests updated for the pointer type.

## Verification

- `go build ./...`, `go vet`, `gofmt`, `go test -race ./internal/generators/anthropic/` and `./pkg/config/` all green.
- **Live:** `augustus scan anthropic.Anthropic -m claude-sonnet-5 --probe dan.Dan_11_0 --detector dan.DAN` (no temperature) now returns a real response (`error: none`), where it previously failed with the deprecation error.

## Context

Surfaced while validating the image-probe work in [LAB-2417](https://linear.app/praetorianlabs/issue/LAB-2417) (PR #228) against live vision models — the `temperature` rejection blocked testing any probe against the newest Claude models. This is an independent generator fix, kept in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)