### PR TITLE
feat: add Gemini/Vertex document (PDF) wire transport (LAB-4193)

### DIFF
--- a/internal/generators/gemini/gemini.go
+++ b/internal/generators/gemini/gemini.go
@@ -217,7 +217,7 @@ func (g *Gemini) generateOne(ctx context.Context, conv *attempt.Conversation) (a
 func (g *Gemini) conversationToContents(conv *attempt.Conversation) ([]googleai.Content, error) {
 	contents := make([]googleai.Content, 0, len(conv.Turns)*2)
 	for _, turn := range conv.Turns {
-		parts, err := buildParts(turn.Prompt.Content, turn.Prompt.Images)
+		parts, err := buildParts(turn.Prompt.Content, turn.Prompt.Images, turn.Prompt.Documents)
 		if err != nil {
 			return nil, err
 		}
@@ -236,12 +236,13 @@ func (g *Gemini) conversationToContents(conv *attempt.Conversation) ([]googleai.
 }
 
 // buildParts assembles a Gemini parts list: text first (if non-empty), then
-// one inlineData part per image. Image parts are built by the shared
-// googleai.BuildImageParts helper (also used by vertex) so the two Gemini-schema
-// generators cannot diverge on multimodal handling. It returns an error if an
-// image has an unset/unsupported MIME type or cannot be resolved to base64.
-func buildParts(text string, images []attempt.Image) ([]googleai.ContentPart, error) {
-	parts := make([]googleai.ContentPart, 0, 1+len(images))
+// one inlineData part per image, then one inlineData part per document. The
+// media parts are built by the shared googleai.BuildImageParts /
+// BuildDocumentParts helpers (also used by vertex) so the two Gemini-schema
+// generators cannot diverge on multimodal handling. It returns an error if any
+// attachment has an unset/unsupported MIME type or cannot be resolved to base64.
+func buildParts(text string, images []attempt.Image, docs []attempt.Document) ([]googleai.ContentPart, error) {
+	parts := make([]googleai.ContentPart, 0, 1+len(images)+len(docs))
 	if text != "" {
 		parts = append(parts, googleai.ContentPart{Text: text})
 	}
@@ -250,6 +251,11 @@ func buildParts(text string, images []attempt.Image) ([]googleai.ContentPart, er
 		return nil, err
 	}
 	parts = append(parts, imgParts...)
+	docParts, err := googleai.BuildDocumentParts(docs)
+	if err != nil {
+		return nil, err
+	}
+	parts = append(parts, docParts...)
 	return parts, nil
 }
 
@@ -263,6 +269,10 @@ func (g *Gemini) Name() string {
 // See types.VisionCapable.
 func (g *Gemini) SupportsVision() bool { return true }
 
+// SupportsDocuments reports that the Gemini path transmits inlineData document
+// (PDF) parts. See types.DocumentCapable.
+func (g *Gemini) SupportsDocuments() bool { return true }
+
 func (g *Gemini) Description() string {
-	return "Google Gemini API generator (direct API, key-auth; multimodal text + image)"
+	return "Google Gemini API generator (direct API, key-auth; multimodal text + image + document)"
 }

--- a/internal/generators/gemini/gemini_test.go
+++ b/internal/generators/gemini/gemini_test.go
@@ -177,6 +177,46 @@ func TestGeminiGenerator_Generate_WithMultipleImages(t *testing.T) {
 	assert.Equal(t, []string{"image/png", "image/jpeg", "image/webp"}, mimes)
 }
 
+func TestGeminiGenerator_Generate_WithDocument(t *testing.T) {
+	var capturedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mockGeminiResponse("I read the PDF"))
+	}))
+	defer server.Close()
+
+	g := newTestGenerator(t, server.URL)
+	conv := attempt.NewConversation()
+	doc := attempt.Document{Data: []byte("%PDF-1.4 fake"), MimeType: "application/pdf"}
+	conv.AddPromptMessage(attempt.NewUserMessageWithDocuments("summarize", []attempt.Document{doc}))
+
+	resp, err := g.Generate(context.Background(), conv, 1)
+	require.NoError(t, err)
+	require.Len(t, resp, 1)
+	assert.Equal(t, "I read the PDF", resp[0].Content)
+
+	var req googleai.GenerateRequest
+	require.NoError(t, json.Unmarshal(capturedBody, &req))
+	require.Len(t, req.Contents, 1)
+	require.Len(t, req.Contents[0].Parts, 2, "expected text + inlineData document parts")
+
+	// Part 0: text
+	assert.Equal(t, "summarize", req.Contents[0].Parts[0].Text)
+	assert.Nil(t, req.Contents[0].Parts[0].InlineData)
+
+	// Part 1: inlineData (base64 of PDF bytes, application/pdf)
+	assert.Empty(t, req.Contents[0].Parts[1].Text)
+	require.NotNil(t, req.Contents[0].Parts[1].InlineData)
+	assert.Equal(t, "application/pdf", req.Contents[0].Parts[1].InlineData.MimeType)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(doc.Data), req.Contents[0].Parts[1].InlineData.Data)
+}
+
+func TestGeminiGenerator_SupportsDocuments(t *testing.T) {
+	g := newTestGenerator(t, "http://example.invalid")
+	assert.True(t, g.SupportsDocuments())
+}
+
 func TestGeminiGenerator_Generate_WithSystemInstruction(t *testing.T) {
 	var capturedBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/generators/googleai/parts.go
+++ b/internal/generators/googleai/parts.go
@@ -17,6 +17,48 @@ var inlineImageMIMEs = map[string]bool{
 	"image/heif": true,
 }
 
+// inlineDocumentMIMEs is the set of document MIME types Gemini accepts as
+// inline_data on both the direct API and Vertex AI. The document harness
+// (internal/probes/pdf) only produces PDFs, so PDF is the sole supported type;
+// mirrors inlineImageMIMEs and keeps unsupported types a loud error rather than
+// a silently dropped attachment.
+// https://ai.google.dev/gemini-api/docs/document-processing
+var inlineDocumentMIMEs = map[string]bool{
+	"application/pdf": true,
+}
+
+// BuildDocumentParts converts document attachments (e.g. PDFs) into Gemini
+// inline_data parts, base64-encoding each document exactly once via
+// Document.ToBase64. It mirrors BuildImageParts and is called by both the gemini
+// (direct API) and vertex generators so their document handling cannot drift.
+//
+// It returns an error (rather than emitting a part the API will reject) when a
+// document has an unset or unsupported MIME type, fails to encode, or resolves
+// to no data. Callers should surface the error so a dropped attachment never
+// masquerades as a clean text-only request.
+func BuildDocumentParts(docs []attempt.Document) ([]ContentPart, error) {
+	parts := make([]ContentPart, 0, len(docs))
+	for _, doc := range docs {
+		if doc.MimeType == "" {
+			return nil, fmt.Errorf("googleai: document has empty MIME type")
+		}
+		if !inlineDocumentMIMEs[doc.MimeType] {
+			return nil, fmt.Errorf("googleai: unsupported document MIME type %q (want application/pdf)", doc.MimeType)
+		}
+		data, err := doc.ToBase64()
+		if err != nil {
+			return nil, fmt.Errorf("googleai: encode document: %w", err)
+		}
+		if data == "" {
+			return nil, fmt.Errorf("googleai: document has no data (empty Data/Base64/Path)")
+		}
+		parts = append(parts, ContentPart{
+			InlineData: &InlineData{MimeType: doc.MimeType, Data: data},
+		})
+	}
+	return parts, nil
+}
+
 // BuildImageParts converts image attachments into Gemini inline_data parts,
 // base64-encoding each image exactly once via Image.ToBase64.
 //

--- a/internal/generators/googleai/parts_test.go
+++ b/internal/generators/googleai/parts_test.go
@@ -1,0 +1,62 @@
+package googleai
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/augustus/pkg/attempt"
+)
+
+func TestBuildDocumentParts_PDF(t *testing.T) {
+	data := []byte("%PDF-1.4 fake pdf bytes")
+	docs := []attempt.Document{{Data: data, MimeType: "application/pdf"}}
+
+	parts, err := BuildDocumentParts(docs)
+	require.NoError(t, err)
+	require.Len(t, parts, 1)
+	require.NotNil(t, parts[0].InlineData)
+	assert.Equal(t, "application/pdf", parts[0].InlineData.MimeType)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(data), parts[0].InlineData.Data)
+	assert.Empty(t, parts[0].Text)
+}
+
+func TestBuildDocumentParts_MultipleAndBase64Source(t *testing.T) {
+	b64 := base64.StdEncoding.EncodeToString([]byte("second"))
+	docs := []attempt.Document{
+		{Data: []byte("first"), MimeType: "application/pdf"},
+		{Base64: b64, MimeType: "application/pdf"},
+	}
+
+	parts, err := BuildDocumentParts(docs)
+	require.NoError(t, err)
+	require.Len(t, parts, 2)
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("first")), parts[0].InlineData.Data)
+	assert.Equal(t, b64, parts[1].InlineData.Data)
+}
+
+func TestBuildDocumentParts_EmptyInput(t *testing.T) {
+	parts, err := BuildDocumentParts(nil)
+	require.NoError(t, err)
+	assert.Empty(t, parts)
+}
+
+func TestBuildDocumentParts_EmptyMIME(t *testing.T) {
+	_, err := BuildDocumentParts([]attempt.Document{{Data: []byte("x")}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty MIME type")
+}
+
+func TestBuildDocumentParts_UnsupportedMIME(t *testing.T) {
+	_, err := BuildDocumentParts([]attempt.Document{{Data: []byte("x"), MimeType: "image/png"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported document MIME type")
+}
+
+func TestBuildDocumentParts_NoData(t *testing.T) {
+	_, err := BuildDocumentParts([]attempt.Document{{MimeType: "application/pdf"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no data")
+}

--- a/internal/generators/vertex/vertex.go
+++ b/internal/generators/vertex/vertex.go
@@ -296,10 +296,11 @@ func (g *Vertex) generateOne(ctx context.Context, conv *attempt.Conversation) (a
 }
 
 // conversationToContents converts an Augustus Conversation to Vertex AI contents.
-// Images on user turns are emitted as inlineData parts via the shared
-// googleai.BuildImageParts helper (same path as gemini.Gemini); an unset or
-// unsupported image MIME type returns an error rather than silently dropping
-// the attachment and running the probe as a text-only request.
+// Images and documents on user turns are emitted as inlineData parts via the
+// shared googleai.BuildImageParts / BuildDocumentParts helpers (same path as
+// gemini.Gemini); an unset or unsupported attachment MIME type returns an error
+// rather than silently dropping the attachment and running the probe as a
+// text-only request.
 func (g *Vertex) conversationToContents(conv *attempt.Conversation) ([]googleai.Content, error) {
 	contents := make([]googleai.Content, 0)
 
@@ -325,8 +326,8 @@ func (g *Vertex) conversationToContents(conv *attempt.Conversation) ([]googleai.
 			})
 		default:
 			// Standard user message: text part (if non-empty) followed by one
-			// inlineData part per image.
-			parts := make([]googleai.ContentPart, 0, 1+len(turn.Prompt.Images))
+			// inlineData part per image, then one inlineData part per document.
+			parts := make([]googleai.ContentPart, 0, 1+len(turn.Prompt.Images)+len(turn.Prompt.Documents))
 			if turn.Prompt.Content != "" {
 				parts = append(parts, googleai.ContentPart{Text: turn.Prompt.Content})
 			}
@@ -335,6 +336,11 @@ func (g *Vertex) conversationToContents(conv *attempt.Conversation) ([]googleai.
 				return nil, err
 			}
 			parts = append(parts, imgParts...)
+			docParts, err := googleai.BuildDocumentParts(turn.Prompt.Documents)
+			if err != nil {
+				return nil, err
+			}
+			parts = append(parts, docParts...)
 			contents = append(contents, googleai.Content{
 				Role:  "user",
 				Parts: parts,
@@ -376,6 +382,10 @@ func (g *Vertex) Name() string {
 // SupportsVision reports that the Vertex AI path transmits inlineData image
 // parts (Gemini vision). See types.VisionCapable.
 func (g *Vertex) SupportsVision() bool { return true }
+
+// SupportsDocuments reports that the Vertex AI path transmits inlineData
+// document (PDF) parts. See types.DocumentCapable.
+func (g *Vertex) SupportsDocuments() bool { return true }
 
 // Description returns a human-readable description.
 func (g *Vertex) Description() string {

--- a/internal/generators/vertex/vertex_test.go
+++ b/internal/generators/vertex/vertex_test.go
@@ -2,7 +2,9 @@ package vertex
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -12,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/praetorian-inc/augustus/internal/generators/googleai"
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/probes"
@@ -171,6 +174,60 @@ func TestVertexGenerator_Generate_SingleResponse(t *testing.T) {
 	contents, ok := receivedRequest["contents"].([]any)
 	assert.True(t, ok, "should have contents array")
 	assert.Len(t, contents, 1)
+}
+
+func TestVertexGenerator_Generate_WithDocument(t *testing.T) {
+	var capturedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(mockVertexResponse("I read the PDF"))
+	}))
+	defer server.Close()
+
+	g, err := NewVertex(registry.Config{
+		"model":      "gemini-pro",
+		"project_id": "test-project",
+		"location":   "us-central1",
+		"base_url":   server.URL,
+	})
+	require.NoError(t, err)
+
+	conv := attempt.NewConversation()
+	doc := attempt.Document{Data: []byte("%PDF-1.4 fake"), MimeType: "application/pdf"}
+	conv.AddPromptMessage(attempt.NewUserMessageWithDocuments("summarize", []attempt.Document{doc}))
+
+	resp, err := g.Generate(context.Background(), conv, 1)
+	require.NoError(t, err)
+	require.Len(t, resp, 1)
+	assert.Equal(t, "I read the PDF", resp[0].Content)
+
+	// Vertex must emit the same inlineData document part shape as gemini.Gemini
+	// (both delegate to googleai.BuildDocumentParts), keeping the two
+	// Gemini-schema paths in parity.
+	var req googleai.GenerateRequest
+	require.NoError(t, json.Unmarshal(capturedBody, &req))
+	require.Len(t, req.Contents, 1)
+	require.Len(t, req.Contents[0].Parts, 2, "expected text + inlineData document parts")
+
+	assert.Equal(t, "summarize", req.Contents[0].Parts[0].Text)
+	assert.Nil(t, req.Contents[0].Parts[0].InlineData)
+
+	require.NotNil(t, req.Contents[0].Parts[1].InlineData)
+	assert.Equal(t, "application/pdf", req.Contents[0].Parts[1].InlineData.MimeType)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(doc.Data), req.Contents[0].Parts[1].InlineData.Data)
+}
+
+func TestVertexGenerator_SupportsDocuments(t *testing.T) {
+	g, err := NewVertex(registry.Config{
+		"model":      "gemini-pro",
+		"project_id": "test-project",
+		"location":   "us-central1",
+	})
+	require.NoError(t, err)
+	v, ok := g.(*Vertex)
+	require.True(t, ok)
+	assert.True(t, v.SupportsDocuments())
 }
 
 func TestVertexGenerator_Generate_MultipleResponses(t *testing.T) {


### PR DESCRIPTION
## Summary

Wires native PDF/document transport through the **Gemini** and **Vertex** generators so multimodal document probes (`pdf.*`) can run against Google models, not just Anthropic. Previously `attempt.Message.Documents` was silently dropped for both Google providers — `buildParts`/`conversationToContents` carried images only, and neither generator advertised `DocumentCapable`, so the `pdf.*` capability gate skipped them.

This is purely additive generator plumbing on top of the document harness delivered by LAB-2368 (`types.DocumentCapable`, `Message.Documents`, the document path in `RunMultimodalPrompts`).

## Changes

- **`googleai.BuildDocumentParts([]attempt.Document)`** — emits Gemini `inlineData` parts with `mime_type: application/pdf`, base64-encoding each document exactly once via `Document.ToBase64`. Mirrors `BuildImageParts`: returns a loud error on empty/unsupported MIME type or missing data rather than shipping a part the API rejects (or a dropped attachment masquerading as a clean text-only request).
- **gemini** `buildParts` and **vertex** `conversationToContents` now thread documents through, delegating to the shared helper so the two Gemini-schema paths cannot drift.
- **`SupportsDocuments() bool`** (`types.DocumentCapable`) implemented on both generators so the `pdf.*` capability gate no longer skips them.
- Tests: document part construction (happy path, multi-doc, Base64 source, empty/unsupported MIME, no-data errors) plus gemini/vertex wire-shape parity and `SupportsDocuments` gate tests.

## Verification

- `go build ./cmd/augustus` ✅
- `golangci-lint run` on the three affected packages → 0 issues ✅
- All generator + `multimodal`/`pdf` probe tests pass ✅

**Not run here:** the ticket's live acceptance — `augustus scan gemini.Gemini --probes-glob "pdf.*"` scoring ≥1.0 on ≥3/5 probes — requires real Google API credentials and endpoint. The full path is verified structurally (documents reach the wire as `application/pdf` `inlineData`; both generators now pass the runtime `types.DocumentCapable` gate). Live scan still needed to formally close acceptance.

## Ticket

LAB-4193 — https://linear.app/praetorianlabs/issue/LAB-4193

🤖 Generated with [Claude Code](https://claude.com/claude-code)