### PR TITLE
feat: enforce resolveCanary charset for pdf probes (LAB-4315)

### DIFF
--- a/internal/probes/pdf/annotation.go
+++ b/internal/probes/pdf/annotation.go
@@ -11,7 +11,10 @@ import (
 func init() { probes.Register("pdf.AnnotationInjection", newAnnotationInjection) }
 
 func newAnnotationInjection(cfg registry.Config) (probes.Prober, error) {
-	canary := resolveCanary(cfg)
+	canary, err := resolveCanary(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("pdf.AnnotationInjection: %w", err)
+	}
 	data, err := pdfbuild.AnnotationInjection(canary)
 	if err != nil {
 		return nil, fmt.Errorf("pdf.AnnotationInjection: %w", err)

--- a/internal/probes/pdf/invisible.go
+++ b/internal/probes/pdf/invisible.go
@@ -11,7 +11,10 @@ import (
 func init() { probes.Register("pdf.InvisibleText", newInvisibleText) }
 
 func newInvisibleText(cfg registry.Config) (probes.Prober, error) {
-	canary := resolveCanary(cfg)
+	canary, err := resolveCanary(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("pdf.InvisibleText: %w", err)
+	}
 	data, err := pdfbuild.InvisibleText(canary)
 	if err != nil {
 		return nil, fmt.Errorf("pdf.InvisibleText: %w", err)

--- a/internal/probes/pdf/metadata.go
+++ b/internal/probes/pdf/metadata.go
@@ -11,7 +11,10 @@ import (
 func init() { probes.Register("pdf.MetadataInjection", newMetadataInjection) }
 
 func newMetadataInjection(cfg registry.Config) (probes.Prober, error) {
-	canary := resolveCanary(cfg)
+	canary, err := resolveCanary(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("pdf.MetadataInjection: %w", err)
+	}
 	data, err := pdfbuild.MetadataInjection(canary)
 	if err != nil {
 		return nil, fmt.Errorf("pdf.MetadataInjection: %w", err)

--- a/internal/probes/pdf/offpage.go
+++ b/internal/probes/pdf/offpage.go
@@ -11,7 +11,10 @@ import (
 func init() { probes.Register("pdf.OffPageText", newOffPageText) }
 
 func newOffPageText(cfg registry.Config) (probes.Prober, error) {
-	canary := resolveCanary(cfg)
+	canary, err := resolveCanary(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("pdf.OffPageText: %w", err)
+	}
 	data, err := pdfbuild.OffPageText(canary)
 	if err != nil {
 		return nil, fmt.Errorf("pdf.OffPageText: %w", err)

--- a/internal/probes/pdf/onepointfont.go
+++ b/internal/probes/pdf/onepointfont.go
@@ -11,7 +11,10 @@ import (
 func init() { probes.Register("pdf.OnePointFont", newOnePointFont) }
 
 func newOnePointFont(cfg registry.Config) (probes.Prober, error) {
-	canary := resolveCanary(cfg)
+	canary, err := resolveCanary(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("pdf.OnePointFont: %w", err)
+	}
 	data, err := pdfbuild.OnePointFont(canary)
 	if err != nil {
 		return nil, fmt.Errorf("pdf.OnePointFont: %w", err)

--- a/internal/probes/pdf/probe_construction_test.go
+++ b/internal/probes/pdf/probe_construction_test.go
@@ -64,3 +64,54 @@ func TestPDFProbeCanaryOverride(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateCanary checks the charset enforcement directly: compliant canaries
+// pass, and each forbidden-character class is rejected with a descriptive error.
+func TestValidateCanary(t *testing.T) {
+	t.Run("compliant", func(t *testing.T) {
+		for _, ok := range []string{
+			defaultCanary,           // the default must always pass
+			"PURPLE WALRUS 9931",    // spaces and digits are fine
+			"canary-with_symbols!?", // other printable ASCII is fine
+		} {
+			assert.NoError(t, validateCanary(ok), "expected %q to be accepted", ok)
+		}
+	})
+
+	t.Run("forbidden", func(t *testing.T) {
+		for _, bad := range []string{
+			"open (paren",
+			"close paren)",
+			`back\slash`,
+			"comma,delimited",
+			"semi;colon",
+			"line\nbreak", // newline is not printable ASCII
+			"tab\tinside", // control character
+			"unicode-é",   // non-ASCII rune
+		} {
+			assert.Error(t, validateCanary(bad), "expected %q to be rejected", bad)
+		}
+	})
+}
+
+// TestPDFProbeRejectsMalformedCanary verifies a forbidden operator canary fails at
+// probe construction with an actionable error naming the probe, rather than
+// surfacing later as a broken PDF/metadata round-trip mid-scan.
+func TestPDFProbeRejectsMalformedCanary(t *testing.T) {
+	names := []string{
+		"pdf.InvisibleText", "pdf.OffPageText", "pdf.OnePointFont",
+		"pdf.MetadataInjection", "pdf.AnnotationInjection",
+	}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			factory, ok := probes.Get(name)
+			require.True(t, ok, "%s must be registered", name)
+
+			p, err := factory(registry.Config{"canary": "bad,canary;value"})
+			require.Error(t, err)
+			assert.Nil(t, p)
+			assert.Contains(t, err.Error(), name, "error should name the probe")
+			assert.Contains(t, err.Error(), "canary", "error should describe the problem")
+		})
+	}
+}

--- a/internal/probes/pdf/probe_construction_test.go
+++ b/internal/probes/pdf/probe_construction_test.go
@@ -1,6 +1,7 @@
 package pdf
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,12 +12,15 @@ import (
 	"github.com/praetorian-inc/augustus/pkg/registry"
 )
 
+// pdfProbeNames is the list of all registered PDF probe names, shared across the
+// construction and canary tests so adding a probe updates coverage in one place.
+var pdfProbeNames = []string{
+	"pdf.InvisibleText", "pdf.OffPageText", "pdf.OnePointFont",
+	"pdf.MetadataInjection", "pdf.AnnotationInjection",
+}
+
 func TestPDFProbeConstruction(t *testing.T) {
-	names := []string{
-		"pdf.InvisibleText", "pdf.OffPageText", "pdf.OnePointFont",
-		"pdf.MetadataInjection", "pdf.AnnotationInjection",
-	}
-	for _, name := range names {
+	for _, name := range pdfProbeNames {
 		t.Run(name, func(t *testing.T) {
 			factory, ok := probes.Get(name)
 			require.True(t, ok, "%s must be registered", name)
@@ -45,11 +49,7 @@ func TestPDFProbeConstruction(t *testing.T) {
 // defaultCanary.
 func TestPDFProbeCanaryOverride(t *testing.T) {
 	const override = "PURPLE WALRUS 9931"
-	names := []string{
-		"pdf.InvisibleText", "pdf.OffPageText", "pdf.OnePointFont",
-		"pdf.MetadataInjection", "pdf.AnnotationInjection",
-	}
-	for _, name := range names {
+	for _, name := range pdfProbeNames {
 		t.Run(name, func(t *testing.T) {
 			factory, ok := probes.Get(name)
 			require.True(t, ok, "%s must be registered", name)
@@ -85,12 +85,18 @@ func TestValidateCanary(t *testing.T) {
 			`back\slash`,
 			"comma,delimited",
 			"semi;colon",
-			"line\nbreak", // newline is not printable ASCII
-			"tab\tinside", // control character
-			"unicode-é",   // non-ASCII rune
+			"line\nbreak",                       // newline is not printable ASCII
+			"tab\tinside",                       // control character
+			"unicode-é",                         // non-ASCII rune
+			strings.Repeat("A", maxCanaryLen+1), // exceeds the length bound
 		} {
 			assert.Error(t, validateCanary(bad), "expected %q to be rejected", bad)
 		}
+	})
+
+	t.Run("max length boundary", func(t *testing.T) {
+		assert.NoError(t, validateCanary(strings.Repeat("A", maxCanaryLen)),
+			"a canary exactly at the length bound should be accepted")
 	})
 }
 
@@ -98,11 +104,7 @@ func TestValidateCanary(t *testing.T) {
 // probe construction with an actionable error naming the probe, rather than
 // surfacing later as a broken PDF/metadata round-trip mid-scan.
 func TestPDFProbeRejectsMalformedCanary(t *testing.T) {
-	names := []string{
-		"pdf.InvisibleText", "pdf.OffPageText", "pdf.OnePointFont",
-		"pdf.MetadataInjection", "pdf.AnnotationInjection",
-	}
-	for _, name := range names {
+	for _, name := range pdfProbeNames {
 		t.Run(name, func(t *testing.T) {
 			factory, ok := probes.Get(name)
 			require.True(t, ok, "%s must be registered", name)

--- a/internal/probes/pdf/probes.go
+++ b/internal/probes/pdf/probes.go
@@ -22,6 +22,12 @@ const defaultCanary = "MARITIME GIRAFFE 4827"
 // channel.
 const forbiddenCanaryChars = `()\,;`
 
+// maxCanaryLen bounds an operator-supplied canary. A canary is a short phrase the
+// fuzzy multimodal.Canary detector matches on, so this is generous — its purpose
+// is to reject pathologically large input up front rather than let it flow into
+// PDF string construction (the PDF spec caps literal strings at 65,535 bytes).
+const maxCanaryLen = 256
+
 // resolveCanary returns the operator-supplied canary or the default, rejecting an
 // operator canary that violates the documented charset (see validateCanary).
 //
@@ -52,6 +58,9 @@ func resolveCanary(cfg registry.Config) (string, error) {
 // forbiddenCanaryChars — parentheses, backslashes, commas, or semicolons. See the
 // resolveCanary doc comment for the per-channel rationale.
 func validateCanary(canary string) error {
+	if len(canary) > maxCanaryLen {
+		return fmt.Errorf("canary is %d bytes: must be at most %d bytes", len(canary), maxCanaryLen)
+	}
 	for i, r := range canary {
 		switch {
 		case r < 0x20 || r > 0x7e:

--- a/internal/probes/pdf/probes.go
+++ b/internal/probes/pdf/probes.go
@@ -4,6 +4,9 @@
 package pdf
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/praetorian-inc/augustus/internal/probes/multimodal"
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/registry"
@@ -13,7 +16,14 @@ import (
 // via the "canary" config key.
 const defaultCanary = "MARITIME GIRAFFE 4827"
 
-// resolveCanary returns the operator-supplied canary or the default.
+// forbiddenCanaryChars are the characters an operator-supplied canary must not
+// contain (in addition to the printable-ASCII requirement enforced by
+// validateCanary). See the resolveCanary doc comment for why each one breaks a
+// channel.
+const forbiddenCanaryChars = `()\,;`
+
+// resolveCanary returns the operator-supplied canary or the default, rejecting an
+// operator canary that violates the documented charset (see validateCanary).
 //
 // NOTE: for the text-layout probes (Invisible/OffPage/OnePointFont) the canary is
 // emitted into a PDF content stream as `(canary) Tj`. The characters `(`, `)`, and
@@ -24,12 +34,33 @@ const defaultCanary = "MARITIME GIRAFFE 4827"
 // delimiters fragments and breaks the api.PDFInfo Keywords round-trip. Keep
 // operator-supplied canaries to printable ASCII WITHOUT parentheses, backslashes,
 // commas, semicolons, or newlines (the default phrase already complies). Spaces
-// and digits are fine; detector matching is fuzzy/normalized.
-func resolveCanary(cfg registry.Config) string {
+// and digits are fine; detector matching is fuzzy/normalized. This constraint is
+// enforced up front by validateCanary so a malformed canary fails at probe
+// construction with an actionable error rather than mid-scan.
+func resolveCanary(cfg registry.Config) (string, error) {
 	if c := registry.GetString(cfg, "canary", ""); c != "" {
-		return c
+		if err := validateCanary(c); err != nil {
+			return "", fmt.Errorf("invalid operator-supplied canary %q: %w", c, err)
+		}
+		return c, nil
 	}
-	return defaultCanary
+	return defaultCanary, nil
+}
+
+// validateCanary enforces the documented canary charset: printable ASCII only
+// (0x20–0x7E, which excludes newlines and other control characters), and none of
+// forbiddenCanaryChars — parentheses, backslashes, commas, or semicolons. See the
+// resolveCanary doc comment for the per-channel rationale.
+func validateCanary(canary string) error {
+	for i, r := range canary {
+		switch {
+		case r < 0x20 || r > 0x7e:
+			return fmt.Errorf("character %q at byte %d is not printable ASCII: canary must be printable ASCII (0x20-0x7E) without newlines", r, i)
+		case strings.ContainsRune(forbiddenCanaryChars, r):
+			return fmt.Errorf("character %q at byte %d is forbidden: canary must not contain any of %q (parentheses, backslashes, commas, or semicolons break PDF content-stream or metadata round-trips)", r, i, forbiddenCanaryChars)
+		}
+	}
+	return nil
 }
 
 // victimPrompt is the benign request a real user sends when handing a model an


### PR DESCRIPTION
## Summary

Follow-up from LAB-2368 / PR #203, raised in the final whole-branch code review.

`resolveCanary` (`internal/probes/pdf/probes.go`) lets an operator override the embedded canary via the `canary` config key. The documented constraint — operator canaries must be printable ASCII **without** parentheses, backslashes, commas, semicolons, or newlines — was **advisory only**. A malformed canary would surface as a confusing mid-scan failure (e.g. a broken metadata round-trip) rather than a clear up-front rejection.

This PR enforces the charset at probe construction:

- `resolveCanary` now returns `(string, error)` and validates an operator-supplied canary via a new `validateCanary` helper — printable ASCII (0x20–0x7E, excluding newlines/control chars) and none of `()\,;` (hoisted into a `forbiddenCanaryChars` constant).
- Each of the five probe factories (`InvisibleText`, `OffPageText`, `OnePointFont`, `MetadataInjection`, `AnnotationInjection`) checks the error and wraps it with its probe name, so a bad canary fails at construction with an actionable message instead of mid-scan.
- The default canary complies, so **default behavior is unchanged**.

## Why

- Text-layout probes emit the canary into a content stream as `(canary) Tj` — `(`, `)`, `\` are escaped and newlines split the run across operators.
- `pdf.MetadataInjection` stores the canary as a `/Keywords` entry, which pdfcpu parses by splitting on `,`, `;`, and `\r` — a canary containing those delimiters fragments and breaks the `api.PDFInfo` Keywords round-trip.

## Tests

- `TestValidateCanary` — compliant canaries (incl. the default) pass; each forbidden class (parens, backslash, comma, semicolon, newline, tab, non-ASCII) is rejected.
- `TestPDFProbeRejectsMalformedCanary` — a forbidden canary fails every factory with an error naming the probe.

## Verification

- `go build ./...` — clean
- `go test ./internal/probes/pdf/...` — all pass
- `golangci-lint fmt` — applied

Closes LAB-4315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)