### PR TITLE
ci: revert leaderboard-metrics pin to v2.16.3 to fix OIDC AssumeRole

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,14 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+    ignore:
+      # The leaderboard-metrics pin is coupled to the metrics IAM trust in
+      # guard (LeaderboardMetricsRole), which allow-lists the exact pinned
+      # SHA. Bumping it must follow the ENG-4164 runbook (update the trust +
+      # prod deploy BEFORE rolling the pin) — an uncoordinated Dependabot bump
+      # breaks OIDC AssumeRole (#241). Roll this pin manually as part of that
+      # runbook.
+      - dependency-name: "praetorian-inc/public-workflows/.github/workflows/leaderboard-metrics.yml"
 
   - package-ecosystem: "gomod"
     directory: "/"

--- a/.github/workflows/leaderboard-metrics.yml
+++ b/.github/workflows/leaderboard-metrics.yml
@@ -11,6 +11,10 @@ permissions:
 
 jobs:
   metrics:
-    uses: praetorian-inc/public-workflows/.github/workflows/leaderboard-metrics.yml@dc359d4cf6ade393f811c13533b1a3abb780f5d1 # v2.16.7
+    # Pinned to v2.16.3: the metrics IAM trust (guard LeaderboardMetricsRole)
+    # only lists this SHA's job_workflow_ref. Bumping the pin is gated on the
+    # ENG-4164 runbook (add new SHA to the trust + prod deploy FIRST); see the
+    # Dependabot ignore below. Uncoordinated bump to v2.16.7 broke OIDC (#241).
+    uses: praetorian-inc/public-workflows/.github/workflows/leaderboard-metrics.yml@c351826e6de27cadeb5b32ce81157355b283518b # v2.16.3
     with:
       capability_map: '[{"path": ".", "name": "augustus"}]'


### PR DESCRIPTION
## What

Reverts the leaderboard-metrics reusable-workflow pin from **v2.16.7** (`dc359d4c`) back to **v2.16.3** (`c351826e`), and adds a Dependabot `ignore` for this dependency.

## Why

Dependabot **#241** (merged 2026-07-13 19:37Z) bumped the pin v2.16.3 → v2.16.7. The metrics IAM trust in **guard** (`LeaderboardMetricsRole`) allow-lists the exact pinned SHA's `job_workflow_ref` claim as an STS condition, and **only v2.16.3's SHA is listed**. So every *merged*-PR metrics run since that bump fails at:

```
Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity
```

(Closed-unmerged PRs skip the AWS step and show green, which masked it.) Last good run was 19:11Z on v2.16.3; everything from 19:38Z on fails.

Per the v2.16.7 workflow header, bumping this pin requires the **ENG-4164 runbook**: add the new SHA to the guard trust + prod deploy **first**, then roll caller pins. Dependabot did an uncoordinated roll. This reverts to the SHA the trust accepts and adds an `ignore` so the pin is only advanced manually as part of that runbook.

## Notes
- `pull_request_target` reads this workflow from `main`, so the fix takes effect **once merged** — this PR's own metrics run won't be green until then.
- Forward path (fleet → v2.16.7) is Security Engineering's ENG-4164 runbook in guard; unaffected by this revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)