### PR TITLE
feat(probes): expose curated RiskInfo write-ups on MCP probes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Probes may also implement these **optional** interfaces (all in `pkg/types/probe
 - **ProbeDetectorConfig**: `GetDetectorConfig()` — per-probe detector config overrides
 - **ProbeSecondaryDetectors**: `GetSecondaryDetectors()` — run extra detectors alongside the primary; the attempt verdict reflects the **max score across all detectors** (see `attempt.GetEffectiveScores`), so a secondary hit alone marks the attempt vulnerable
 - **ProbeTools**: `GetTools()` / `GetToolChoice()` — declare function-calling tool schemas for tool-use/agent probes (sent via the native wire layer in `internal/attackengine/toolcalls.go`)
+- **RiskDescriber**: `RiskInfo()` — carry a curated `types.RiskInfo` write-up (description/impact/recommendation/references/taxonomies/CVSS v4.0 vector) next to the probe so consumers retrieve it via type assertion instead of duplicating it
 
 Generators may also implement these **optional** interfaces (in `pkg/types/generator.go`):
 - **UsageReporter**: `AccumulatedTokens() int64` — reports the cumulative tokens consumed across all `Generate` calls. The scanner type-asserts each generator for this interface and records the per-run delta into `Metrics.TokensConsumed` (surfaced as `augustus_tokens_consumed`). Implement it for free by embedding `types.UsageCounter` (a concurrency-safe `atomic.Int64`) and calling `g.AddTokens(...)` wherever the provider returns usage. Generators whose provider doesn't report usage still embed `UsageCounter` and simply never `AddTokens`, contributing 0 (honest partial coverage, never an estimate).

--- a/internal/probes/mcpconfig/credentialexposure.go
+++ b/internal/probes/mcpconfig/credentialexposure.go
@@ -130,6 +130,7 @@ func (p *CredentialExposure) RiskInfo() types.RiskInfo {
 		Recommendation: "Keep credentials out of committed configuration: load them from a secrets manager or injected environment at runtime, reference them indirectly rather than inlining values, and rotate any secret that has already been committed. Scope each credential to least privilege.",
 		References:     "https://cwe.mitre.org/data/definitions/798.html\nhttps://cwe.mitre.org/data/definitions/312.html\nhttps://owasp.org/www-project-top-10-for-large-language-model-applications/",
 		Taxonomies:     "- cwe: 798\n- cwe: 312\n- cwe: 200",
+		CVSSVector:     "CVSS:4.0/AV:L/AC:L/AT:N/PR:L/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N",
 	}
 }
 

--- a/internal/probes/mcpconfig/credentialexposure.go
+++ b/internal/probes/mcpconfig/credentialexposure.go
@@ -120,6 +120,19 @@ func (p *CredentialExposure) informational() *attempt.Attempt {
 // Name returns the fully qualified probe name.
 func (p *CredentialExposure) Name() string { return probeName }
 
+var _ types.RiskDescriber = (*CredentialExposure)(nil)
+
+// RiskInfo is the curated security write-up for this probe's finding.
+func (p *CredentialExposure) RiskInfo() types.RiskInfo {
+	return types.RiskInfo{
+		Description:    "An MCP server's configuration, .env files, or connection strings contain hard-coded credentials — provider API keys, secret-named values, or URI userinfo.",
+		Impact:         "Anyone able to read the configuration (a source repo, an image layer, a shared config directory) obtains working credentials for the services the server integrates with.",
+		Recommendation: "Keep credentials out of committed configuration: load them from a secrets manager or injected environment at runtime, reference them indirectly rather than inlining values, and rotate any secret that has already been committed. Scope each credential to least privilege.",
+		References:     "https://cwe.mitre.org/data/definitions/798.html\nhttps://cwe.mitre.org/data/definitions/312.html\nhttps://owasp.org/www-project-top-10-for-large-language-model-applications/",
+		Taxonomies:     "- cwe: 798\n- cwe: 312\n- cwe: 200",
+	}
+}
+
 // Description returns a human-readable description.
 func (p *CredentialExposure) Description() string {
 	return "Scores MCP server configuration gathered by the recon.MCPConfig module for exposed credentials"

--- a/internal/probes/mcpconfig/riskinfo_test.go
+++ b/internal/probes/mcpconfig/riskinfo_test.go
@@ -21,7 +21,7 @@ func TestRiskInfo_Populated(t *testing.T) {
 		}
 		info := rd.RiskInfo()
 		if info.Description == "" || info.Impact == "" || info.Recommendation == "" ||
-			info.References == "" || info.Taxonomies == "" {
+			info.References == "" || info.Taxonomies == "" || info.CVSSVector == "" {
 			t.Errorf("%s RiskInfo has empty field(s): %+v", p.Name(), info)
 		}
 	}

--- a/internal/probes/mcpconfig/riskinfo_test.go
+++ b/internal/probes/mcpconfig/riskinfo_test.go
@@ -1,0 +1,28 @@
+package mcpconfig
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/augustus/pkg/probes"
+	"github.com/praetorian-inc/augustus/pkg/types"
+)
+
+// TestRiskInfo_Populated verifies the mcpconfig probe exposes a complete
+// RiskDescriber write-up. RiskInfo returns a literal, so a zero-value struct
+// suffices — no construction needed.
+func TestRiskInfo_Populated(t *testing.T) {
+	for _, p := range []probes.Prober{
+		&CredentialExposure{},
+	} {
+		rd, ok := p.(types.RiskDescriber)
+		if !ok {
+			t.Errorf("%s does not implement types.RiskDescriber", p.Name())
+			continue
+		}
+		info := rd.RiskInfo()
+		if info.Description == "" || info.Impact == "" || info.Recommendation == "" ||
+			info.References == "" || info.Taxonomies == "" {
+			t.Errorf("%s RiskInfo has empty field(s): %+v", p.Name(), info)
+		}
+	}
+}

--- a/internal/probes/mcpconfig/riskinfo_test.go
+++ b/internal/probes/mcpconfig/riskinfo_test.go
@@ -1,6 +1,7 @@
 package mcpconfig
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/praetorian-inc/augustus/pkg/probes"
@@ -23,6 +24,9 @@ func TestRiskInfo_Populated(t *testing.T) {
 		if info.Description == "" || info.Impact == "" || info.Recommendation == "" ||
 			info.References == "" || info.Taxonomies == "" || info.CVSSVector == "" {
 			t.Errorf("%s RiskInfo has empty field(s): %+v", p.Name(), info)
+		}
+		if !strings.HasPrefix(info.CVSSVector, "CVSS:4.0/") {
+			t.Errorf("%s CVSSVector is not a CVSS v4.0 vector: %q", p.Name(), info.CVSSVector)
 		}
 	}
 }

--- a/internal/probes/mcptool/bola.go
+++ b/internal/probes/mcptool/bola.go
@@ -71,6 +71,7 @@ func (p *BOLA) RiskInfo() types.RiskInfo {
 		Recommendation: "Check ownership on every access — scope each lookup to the caller's identity (filter by owner/tenant server-side) — and return an identical not-found for objects the caller may not access. Don't rely on identifier unpredictability, and apply the same check to every tool that takes an object identifier.",
 		References:     "https://cwe.mitre.org/data/definitions/639.html\nhttps://owasp.org/API-Security/editions/2023/en/0xa1-broken-object-level-authorization/",
 		Taxonomies:     "- cwe: 639\n- cwe: 284\n- cwe: 285",
+		CVSSVector:     "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
 	}
 }
 

--- a/internal/probes/mcptool/bola.go
+++ b/internal/probes/mcptool/bola.go
@@ -61,6 +61,19 @@ func NewBOLA(cfg registry.Config) (probes.Prober, error) {
 
 func (p *BOLA) Name() string { return "mcptool.BOLA" }
 
+var _ types.RiskDescriber = (*BOLA)(nil)
+
+// RiskInfo is the curated security write-up for this probe's finding.
+func (p *BOLA) RiskInfo() types.RiskInfo {
+	return types.RiskInfo{
+		Description:    "A directly-invokable MCP tool returns an object by identifier without checking that the caller owns it (broken object-level authorization).",
+		Impact:         "A caller can read other identities' objects by supplying their identifiers, which are often sequential or enumerable. Where a mutating tool shares the flaw, the same gap allows cross-identity modification.",
+		Recommendation: "Check ownership on every access — scope each lookup to the caller's identity (filter by owner/tenant server-side) — and return an identical not-found for objects the caller may not access. Don't rely on identifier unpredictability, and apply the same check to every tool that takes an object identifier.",
+		References:     "https://cwe.mitre.org/data/definitions/639.html\nhttps://owasp.org/API-Security/editions/2023/en/0xa1-broken-object-level-authorization/",
+		Taxonomies:     "- cwe: 639\n- cwe: 284\n- cwe: 285",
+	}
+}
+
 func (p *BOLA) Description() string {
 	return "Replays other identities' confirmed object identifiers against the attacker's session, recording attack + positive/negative control responses for the mcptool.BOLA detector to adjudicate a cross-tenant object read (BOLA)"
 }

--- a/internal/probes/mcptool/injection.go
+++ b/internal/probes/mcptool/injection.go
@@ -66,6 +66,19 @@ func NewInjection(cfg registry.Config) (probes.Prober, error) {
 
 func (p *Injection) Name() string { return "mcptool.Injection" }
 
+var _ types.RiskDescriber = (*Injection)(nil)
+
+// RiskInfo is the curated security write-up for this probe's finding.
+func (p *Injection) RiskInfo() types.RiskInfo {
+	return types.RiskInfo{
+		Description:    "A directly-invokable MCP tool passes attacker-controlled arguments to a code, command, or template evaluation sink instead of treating them as data.",
+		Impact:         "A caller who can invoke the tool can run code, OS commands, or template expressions in the tool's process, bounded by that process's privileges.",
+		Recommendation: "Don't pass tool arguments to eval/exec, a shell, or a template engine. Parse them with a restricted parser (e.g. an arithmetic-only grammar or ast.literal_eval), validate against an allowlist, and run tools with least privilege.",
+		References:     "https://cwe.mitre.org/data/definitions/94.html\nhttps://cwe.mitre.org/data/definitions/95.html\nhttps://owasp.org/www-project-top-10-for-large-language-model-applications/",
+		Taxonomies:     "- cwe: 94\n- cwe: 95\n- cwe: 78",
+	}
+}
+
 func (p *Injection) Description() string {
 	return "Injects computed canary and out-of-band shell-command payloads into tool arguments to detect code/command/template injection sinks (including blind OS command injection) in directly-invokable tools"
 }

--- a/internal/probes/mcptool/injection.go
+++ b/internal/probes/mcptool/injection.go
@@ -76,6 +76,7 @@ func (p *Injection) RiskInfo() types.RiskInfo {
 		Recommendation: "Don't pass tool arguments to eval/exec, a shell, or a template engine. Parse them with a restricted parser (e.g. an arithmetic-only grammar or ast.literal_eval), validate against an allowlist, and run tools with least privilege.",
 		References:     "https://cwe.mitre.org/data/definitions/94.html\nhttps://cwe.mitre.org/data/definitions/95.html\nhttps://owasp.org/www-project-top-10-for-large-language-model-applications/",
 		Taxonomies:     "- cwe: 94\n- cwe: 95\n- cwe: 78",
+		CVSSVector:     "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
 	}
 }
 

--- a/internal/probes/mcptool/pathtraversal.go
+++ b/internal/probes/mcptool/pathtraversal.go
@@ -168,6 +168,7 @@ func (p *PathTraversal) RiskInfo() types.RiskInfo {
 		Recommendation: "Canonicalize the path (absolute, symlinks resolved) and reject it unless it resolves within an allowlisted base directory — compare the resolved path, not the raw string. Prefer opaque server-side file identifiers over caller-supplied paths, and run the tool with least privilege.",
 		References:     "https://cwe.mitre.org/data/definitions/22.html\nhttps://cwe.mitre.org/data/definitions/73.html\nhttps://owasp.org/www-community/attacks/Path_Traversal",
 		Taxonomies:     "- cwe: 22\n- cwe: 23\n- cwe: 73",
+		CVSSVector:     "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N",
 	}
 }
 

--- a/internal/probes/mcptool/pathtraversal.go
+++ b/internal/probes/mcptool/pathtraversal.go
@@ -158,6 +158,19 @@ func NewPathTraversal(cfg registry.Config) (probes.Prober, error) {
 
 func (p *PathTraversal) Name() string { return "mcptool.PathTraversal" }
 
+var _ types.RiskDescriber = (*PathTraversal)(nil)
+
+// RiskInfo is the curated security write-up for this probe's finding.
+func (p *PathTraversal) RiskInfo() types.RiskInfo {
+	return types.RiskInfo{
+		Description:    "A directly-invokable MCP tool exposes a filesystem-path parameter that is not confined to its intended directory, allowing access to files outside the sandbox — including via prefix-preserving payloads that defeat a naive startsWith check.",
+		Impact:         "A caller can read files the tool's process can access beyond the intended directory. Where the parameter feeds a write, it also allows creating or overwriting files at chosen paths.",
+		Recommendation: "Canonicalize the path (absolute, symlinks resolved) and reject it unless it resolves within an allowlisted base directory — compare the resolved path, not the raw string. Prefer opaque server-side file identifiers over caller-supplied paths, and run the tool with least privilege.",
+		References:     "https://cwe.mitre.org/data/definitions/22.html\nhttps://cwe.mitre.org/data/definitions/73.html\nhttps://owasp.org/www-community/attacks/Path_Traversal",
+		Taxonomies:     "- cwe: 22\n- cwe: 23\n- cwe: 73",
+	}
+}
+
 func (p *PathTraversal) Description() string {
 	return "Tests directly-invokable tools for filesystem path traversal. Read-only tools get /etc/passwd-class payloads detected via file-content signatures; write-capable tools get novel /tmp/proof-<canary> payloads detected via canary echo — non-destructive proof of arbitrary-path writes without overwriting sensitive files."
 }

--- a/internal/probes/mcptool/responseleak.go
+++ b/internal/probes/mcptool/responseleak.go
@@ -102,6 +102,7 @@ func (p *ResponseLeak) RiskInfo() types.RiskInfo {
 		Recommendation: "Keep secrets out of tool output: return generic errors, disable debug/verbose responses in production, and redact credential-shaped values before returning configuration or diagnostics. Scope each tool's own credentials to least privilege so a leak is contained.",
 		References:     "https://cwe.mitre.org/data/definitions/200.html\nhttps://cwe.mitre.org/data/definitions/209.html\nhttps://cwe.mitre.org/data/definitions/532.html\nhttps://owasp.org/www-project-top-10-for-large-language-model-applications/",
 		Taxonomies:     "- cwe: 200\n- cwe: 209\n- cwe: 532",
+		CVSSVector:     "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
 	}
 }
 

--- a/internal/probes/mcptool/responseleak.go
+++ b/internal/probes/mcptool/responseleak.go
@@ -92,6 +92,19 @@ func NewResponseLeak(cfg registry.Config) (probes.Prober, error) {
 
 func (p *ResponseLeak) Name() string { return "mcptool.ResponseLeak" }
 
+var _ types.RiskDescriber = (*ResponseLeak)(nil)
+
+// RiskInfo is the curated security write-up for this probe's finding.
+func (p *ResponseLeak) RiskInfo() types.RiskInfo {
+	return types.RiskInfo{
+		Description:    "A directly-invokable MCP tool returns credentials or secrets in its response — for example in verbose errors, debug output, or echoed configuration.",
+		Impact:         "A caller can collect API keys, tokens, or connection strings the tool exposes and reuse them against the systems those credentials protect.",
+		Recommendation: "Keep secrets out of tool output: return generic errors, disable debug/verbose responses in production, and redact credential-shaped values before returning configuration or diagnostics. Scope each tool's own credentials to least privilege so a leak is contained.",
+		References:     "https://cwe.mitre.org/data/definitions/200.html\nhttps://cwe.mitre.org/data/definitions/209.html\nhttps://cwe.mitre.org/data/definitions/532.html\nhttps://owasp.org/www-project-top-10-for-large-language-model-applications/",
+		Taxonomies:     "- cwe: 200\n- cwe: 209\n- cwe: 532",
+	}
+}
+
 func (p *ResponseLeak) Description() string {
 	return "Invokes each tool with inputs that surface secrets in the response (verbose errors, debug output, echoed config) and scores responses for exposed credentials"
 }

--- a/internal/probes/mcptool/riskinfo_test.go
+++ b/internal/probes/mcptool/riskinfo_test.go
@@ -21,7 +21,7 @@ func TestRiskInfo_Populated(t *testing.T) {
 		}
 		info := rd.RiskInfo()
 		if info.Description == "" || info.Impact == "" || info.Recommendation == "" ||
-			info.References == "" || info.Taxonomies == "" {
+			info.References == "" || info.Taxonomies == "" || info.CVSSVector == "" {
 			t.Errorf("%s RiskInfo has empty field(s): %+v", p.Name(), info)
 		}
 	}

--- a/internal/probes/mcptool/riskinfo_test.go
+++ b/internal/probes/mcptool/riskinfo_test.go
@@ -1,6 +1,7 @@
 package mcptool
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/praetorian-inc/augustus/pkg/probes"
@@ -23,6 +24,9 @@ func TestRiskInfo_Populated(t *testing.T) {
 		if info.Description == "" || info.Impact == "" || info.Recommendation == "" ||
 			info.References == "" || info.Taxonomies == "" || info.CVSSVector == "" {
 			t.Errorf("%s RiskInfo has empty field(s): %+v", p.Name(), info)
+		}
+		if !strings.HasPrefix(info.CVSSVector, "CVSS:4.0/") {
+			t.Errorf("%s CVSSVector is not a CVSS v4.0 vector: %q", p.Name(), info.CVSSVector)
 		}
 	}
 }

--- a/internal/probes/mcptool/riskinfo_test.go
+++ b/internal/probes/mcptool/riskinfo_test.go
@@ -1,0 +1,28 @@
+package mcptool
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/augustus/pkg/probes"
+	"github.com/praetorian-inc/augustus/pkg/types"
+)
+
+// TestRiskInfo_Populated verifies every mcptool probe exposes a complete
+// RiskDescriber write-up (the finding definition Guard renders). RiskInfo returns
+// a literal, so zero-value structs are sufficient — no construction needed.
+func TestRiskInfo_Populated(t *testing.T) {
+	for _, p := range []probes.Prober{
+		&Injection{}, &SSRF{}, &BOLA{}, &PathTraversal{}, &ResponseLeak{},
+	} {
+		rd, ok := p.(types.RiskDescriber)
+		if !ok {
+			t.Errorf("%s does not implement types.RiskDescriber", p.Name())
+			continue
+		}
+		info := rd.RiskInfo()
+		if info.Description == "" || info.Impact == "" || info.Recommendation == "" ||
+			info.References == "" || info.Taxonomies == "" {
+			t.Errorf("%s RiskInfo has empty field(s): %+v", p.Name(), info)
+		}
+	}
+}

--- a/internal/probes/mcptool/ssrf.go
+++ b/internal/probes/mcptool/ssrf.go
@@ -60,6 +60,19 @@ func NewSSRF(cfg registry.Config) (probes.Prober, error) {
 
 func (p *SSRF) Name() string { return "mcptool.SSRF" }
 
+var _ types.RiskDescriber = (*SSRF)(nil)
+
+// RiskInfo is the curated security write-up for this probe's finding.
+func (p *SSRF) RiskInfo() types.RiskInfo {
+	return types.RiskInfo{
+		Description:    "A directly-invokable MCP tool issues a network request to a URL taken from its arguments without restricting the destination (server-side request forgery).",
+		Impact:         "A caller can direct outbound requests from the tool's host, including to internal services and cloud metadata endpoints (e.g. 169.254.169.254) that are otherwise unreachable.",
+		Recommendation: "Allowlist request destinations by scheme, host, and port; reject private, link-local, and cloud-metadata addresses; re-resolve DNS after validation to defeat rebinding; disable redirects to unvetted hosts; and apply egress filtering on the tool host.",
+		References:     "https://cwe.mitre.org/data/definitions/918.html\nhttps://owasp.org/www-community/attacks/Server_Side_Request_Forgery",
+		Taxonomies:     "- cwe: 918",
+	}
+}
+
 func (p *SSRF) Description() string {
 	return "Injects out-of-band canary URLs into URL-like tool arguments and detects server-side request forgery via callback (blind) or reflected content (non-blind)"
 }

--- a/internal/probes/mcptool/ssrf.go
+++ b/internal/probes/mcptool/ssrf.go
@@ -70,6 +70,7 @@ func (p *SSRF) RiskInfo() types.RiskInfo {
 		Recommendation: "Allowlist request destinations by scheme, host, and port; reject private, link-local, and cloud-metadata addresses; re-resolve DNS after validation to defeat rebinding; disable redirects to unvetted hosts; and apply egress filtering on the tool host.",
 		References:     "https://cwe.mitre.org/data/definitions/918.html\nhttps://owasp.org/www-community/attacks/Server_Side_Request_Forgery",
 		Taxonomies:     "- cwe: 918",
+		CVSSVector:     "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
 	}
 }
 

--- a/internal/probes/mcptransport/originvalidation.go
+++ b/internal/probes/mcptransport/originvalidation.go
@@ -163,6 +163,19 @@ func NewOriginValidation(cfg registry.Config) (probes.Prober, error) {
 
 func (p *OriginValidation) Name() string { return "mcptransport.OriginValidation" }
 
+var _ types.RiskDescriber = (*OriginValidation)(nil)
+
+// RiskInfo is the curated security write-up for this probe's finding.
+func (p *OriginValidation) RiskInfo() types.RiskInfo {
+	return types.RiskInfo{
+		Description:    "An MCP HTTP/SSE endpoint does not validate the Origin (and Host) header the MCP specification requires it to enforce, accepting requests with foreign Origin/Host values a compliant server would reject. Because the endpoint binds to a loopback or private-network address, this is a precondition for DNS rebinding.",
+		Impact:         "A web page the victim visits can reach the local MCP endpoint from the victim's browser and drive its tool surface from outside the assumed local-only boundary. Where credentialed CORS reflection is present, the responses are also exposed to the attacker's origin.",
+		Recommendation: "Allowlist permitted Origin and Host values on every MCP HTTP/SSE request and reject anything else. Don't reflect an arbitrary origin into Access-Control-Allow-Origin, and never pair a reflected origin with Access-Control-Allow-Credentials. Require a per-session token a cross-origin page can't obtain.",
+		References:     "https://cwe.mitre.org/data/definitions/346.html\nhttps://cwe.mitre.org/data/definitions/350.html\nhttps://cwe.mitre.org/data/definitions/942.html\nhttps://nvd.nist.gov/vuln/detail/CVE-2025-49596",
+		Taxonomies:     "- cwe: 346\n- cwe: 350\n- cwe: 942",
+	}
+}
+
 func (p *OriginValidation) Description() string {
 	return "Tests MCP HTTP endpoints for missing Origin/Host validation — the mitigation MCP servers must implement to block browser DNS-rebinding attacks (CVE-2025-49596 class). Classifies the target host at probe time: loopback / RFC1918-LAN targets get full-VULN scoring because they are the browser-driven-rebinding attack path; public endpoints get inconclusive scoring because the same wire finding is CSRF-class rather than rebinding-class there, and exploitability depends on cookie/auth deployment context the probe cannot inspect."
 }

--- a/internal/probes/mcptransport/originvalidation.go
+++ b/internal/probes/mcptransport/originvalidation.go
@@ -173,6 +173,7 @@ func (p *OriginValidation) RiskInfo() types.RiskInfo {
 		Recommendation: "Allowlist permitted Origin and Host values on every MCP HTTP/SSE request and reject anything else. Don't reflect an arbitrary origin into Access-Control-Allow-Origin, and never pair a reflected origin with Access-Control-Allow-Credentials. Require a per-session token a cross-origin page can't obtain.",
 		References:     "https://cwe.mitre.org/data/definitions/346.html\nhttps://cwe.mitre.org/data/definitions/350.html\nhttps://cwe.mitre.org/data/definitions/942.html\nhttps://nvd.nist.gov/vuln/detail/CVE-2025-49596",
 		Taxonomies:     "- cwe: 346\n- cwe: 350\n- cwe: 942",
+		CVSSVector:     "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:A/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N",
 	}
 }
 

--- a/internal/probes/mcptransport/riskinfo_test.go
+++ b/internal/probes/mcptransport/riskinfo_test.go
@@ -21,7 +21,7 @@ func TestRiskInfo_Populated(t *testing.T) {
 		}
 		info := rd.RiskInfo()
 		if info.Description == "" || info.Impact == "" || info.Recommendation == "" ||
-			info.References == "" || info.Taxonomies == "" {
+			info.References == "" || info.Taxonomies == "" || info.CVSSVector == "" {
 			t.Errorf("%s RiskInfo has empty field(s): %+v", p.Name(), info)
 		}
 	}

--- a/internal/probes/mcptransport/riskinfo_test.go
+++ b/internal/probes/mcptransport/riskinfo_test.go
@@ -1,0 +1,28 @@
+package mcptransport
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/augustus/pkg/probes"
+	"github.com/praetorian-inc/augustus/pkg/types"
+)
+
+// TestRiskInfo_Populated verifies every mcptransport probe exposes a complete
+// RiskDescriber write-up. RiskInfo returns a literal, so zero-value structs
+// suffice — no construction needed.
+func TestRiskInfo_Populated(t *testing.T) {
+	for _, p := range []probes.Prober{
+		&OriginValidation{}, &SSESessionHijack{},
+	} {
+		rd, ok := p.(types.RiskDescriber)
+		if !ok {
+			t.Errorf("%s does not implement types.RiskDescriber", p.Name())
+			continue
+		}
+		info := rd.RiskInfo()
+		if info.Description == "" || info.Impact == "" || info.Recommendation == "" ||
+			info.References == "" || info.Taxonomies == "" {
+			t.Errorf("%s RiskInfo has empty field(s): %+v", p.Name(), info)
+		}
+	}
+}

--- a/internal/probes/mcptransport/riskinfo_test.go
+++ b/internal/probes/mcptransport/riskinfo_test.go
@@ -1,6 +1,7 @@
 package mcptransport
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/praetorian-inc/augustus/pkg/probes"
@@ -23,6 +24,9 @@ func TestRiskInfo_Populated(t *testing.T) {
 		if info.Description == "" || info.Impact == "" || info.Recommendation == "" ||
 			info.References == "" || info.Taxonomies == "" || info.CVSSVector == "" {
 			t.Errorf("%s RiskInfo has empty field(s): %+v", p.Name(), info)
+		}
+		if !strings.HasPrefix(info.CVSSVector, "CVSS:4.0/") {
+			t.Errorf("%s CVSSVector is not a CVSS v4.0 vector: %q", p.Name(), info.CVSSVector)
 		}
 	}
 }

--- a/internal/probes/mcptransport/ssesession.go
+++ b/internal/probes/mcptransport/ssesession.go
@@ -91,6 +91,7 @@ func (p *SSESessionHijack) RiskInfo() types.RiskInfo {
 		Recommendation: "Bind each session to its connection and an authenticated principal, and require a secret credential on every request rather than the session ID alone. Generate IDs from a secure RNG, expire them when the stream closes and after an idle timeout, and reject any ID replayed on a different connection.",
 		References:     "https://cwe.mitre.org/data/definitions/287.html\nhttps://cwe.mitre.org/data/definitions/330.html\nhttps://cwe.mitre.org/data/definitions/613.html\nhttps://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html",
 		Taxonomies:     "- cwe: 287\n- cwe: 330\n- cwe: 613",
+		CVSSVector:     "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N",
 	}
 }
 

--- a/internal/probes/mcptransport/ssesession.go
+++ b/internal/probes/mcptransport/ssesession.go
@@ -81,6 +81,19 @@ func NewSSESessionHijack(cfg registry.Config) (probes.Prober, error) {
 
 func (p *SSESessionHijack) Name() string { return "mcptransport.SSESessionHijack" }
 
+var _ types.RiskDescriber = (*SSESessionHijack)(nil)
+
+// RiskInfo is the curated security write-up for this probe's finding.
+func (p *SSESessionHijack) RiskInfo() types.RiskInfo {
+	return types.RiskInfo{
+		Description:    "An MCP server accepts its SSE session identifier as a bearer token that is not bound to the connection or lifetime it was issued for — the ID is honored when replayed on a separate connection or after its stream has closed. Sampled identifiers also showed limited entropy or shared prefixes.",
+		Impact:         "Someone who obtains a session ID — from logs, a Referer header, a proxy, or (given weak entropy) guessing — can reuse it to act with the victim's authority over the MCP tool surface.",
+		Recommendation: "Bind each session to its connection and an authenticated principal, and require a secret credential on every request rather than the session ID alone. Generate IDs from a secure RNG, expire them when the stream closes and after an idle timeout, and reject any ID replayed on a different connection.",
+		References:     "https://cwe.mitre.org/data/definitions/287.html\nhttps://cwe.mitre.org/data/definitions/330.html\nhttps://cwe.mitre.org/data/definitions/613.html\nhttps://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html",
+		Taxonomies:     "- cwe: 287\n- cwe: 330\n- cwe: 613",
+	}
+}
+
 func (p *SSESessionHijack) Description() string {
 	return "Tests MCP SSE session-management for hijack primitives: obtains one valid session ID via a normal SSE handshake, then replays it off the original TCP connection (with stream still open — the true cross-connection replay test) and again after the stream closes. If either replay is accepted, the ID is a naked bearer token that any attacker who obtains it can use to drive the MCP tool surface."
 }

--- a/internal/probes/mcptransport/ssesession.go
+++ b/internal/probes/mcptransport/ssesession.go
@@ -86,11 +86,11 @@ var _ types.RiskDescriber = (*SSESessionHijack)(nil)
 // RiskInfo is the curated security write-up for this probe's finding.
 func (p *SSESessionHijack) RiskInfo() types.RiskInfo {
 	return types.RiskInfo{
-		Description:    "An MCP server accepts its SSE session identifier as a bearer token that is not bound to the connection or lifetime it was issued for — the ID is honored when replayed on a separate connection or after its stream has closed. Sampled identifiers also showed limited entropy or shared prefixes.",
-		Impact:         "Someone who obtains a session ID — from logs, a Referer header, a proxy, or (given weak entropy) guessing — can reuse it to act with the victim's authority over the MCP tool surface.",
-		Recommendation: "Bind each session to its connection and an authenticated principal, and require a secret credential on every request rather than the session ID alone. Generate IDs from a secure RNG, expire them when the stream closes and after an idle timeout, and reject any ID replayed on a different connection.",
-		References:     "https://cwe.mitre.org/data/definitions/287.html\nhttps://cwe.mitre.org/data/definitions/330.html\nhttps://cwe.mitre.org/data/definitions/613.html\nhttps://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html",
-		Taxonomies:     "- cwe: 287\n- cwe: 330\n- cwe: 613",
+		Description:    "An MCP server accepts its SSE session identifier as a bearer token that is not bound to the connection or lifetime it was issued for — the ID is honored when replayed on a separate connection or after its stream has closed.",
+		Impact:         "Someone who obtains a session ID — from logs, a Referer header, a proxy, or network interception — can reuse it to act with the victim's authority over the MCP tool surface.",
+		Recommendation: "Bind each session to its connection and an authenticated principal, and require a secret credential on every request rather than the session ID alone. Expire sessions when the stream closes and after an idle timeout, and reject any ID replayed on a different connection.",
+		References:     "https://cwe.mitre.org/data/definitions/287.html\nhttps://cwe.mitre.org/data/definitions/613.html\nhttps://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html",
+		Taxonomies:     "- cwe: 287\n- cwe: 613",
 		CVSSVector:     "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N",
 	}
 }

--- a/pkg/types/prober.go
+++ b/pkg/types/prober.go
@@ -31,6 +31,37 @@ type ProbeMetadata interface {
 	GetPrompts() []string
 }
 
+// RiskInfo is a probe's curated security write-up for the vulnerability it
+// detects: the vulnerability description and its impact, remediation guidance,
+// newline-separated reference URLs, and a taxonomy-mapping block (e.g. CWE ids).
+// Keeping it on the probe lets a finding's definition live next to the probe
+// logic rather than being duplicated and maintained by each consumer.
+type RiskInfo struct {
+	// Description explains the vulnerability the probe detects (not the probe's
+	// mechanics — that is Description() on ProbeMetadata).
+	Description string
+	// Impact describes what an attacker gains when the vulnerability is present.
+	Impact string
+	// Recommendation is the remediation guidance.
+	Recommendation string
+	// References is a newline-separated list of reference URLs.
+	References string
+	// Taxonomies is a taxonomy-mapping block (e.g. "- cwe: 94\n- cwe: 95").
+	Taxonomies string
+}
+
+// RiskDescriber is an optional interface for probes that carry a curated
+// security write-up (RiskInfo) for the vulnerability they detect. Consumers
+// building a finding/risk definition check for it via type assertion:
+//
+//	if rd, ok := prober.(RiskDescriber); ok { info := rd.RiskInfo(); ... }
+//
+// Probes that don't implement it fall back to the generic ProbeMetadata
+// Description/Goal.
+type RiskDescriber interface {
+	RiskInfo() RiskInfo
+}
+
 // ProbeDetectorConfig is an optional interface for probes that carry
 // per-probe detector configuration overrides.
 // When a probe implements this interface and GetDetectorConfig() returns a

--- a/pkg/types/prober.go
+++ b/pkg/types/prober.go
@@ -48,6 +48,10 @@ type RiskInfo struct {
 	References string
 	// Taxonomies is a taxonomy-mapping block (e.g. "- cwe: 94\n- cwe: 95").
 	Taxonomies string
+	// CVSSVector is the CVSS v4.0 vector string for the vulnerability (e.g.
+	// "CVSS:4.0/AV:N/AC:L/..."). Consumers derive the numeric score from it.
+	// Conservatively scored; optional — empty when the probe has no curated severity.
+	CVSSVector string
 }
 
 // RiskDescriber is an optional interface for probes that carry a curated


### PR DESCRIPTION
## What

Adds an optional `types.RiskDescriber` interface + `types.RiskInfo` struct so a probe can carry its own security write-up (vulnerability description, impact, remediation, references, CWE taxonomy, and a conservatively-scored CVSS v4.0 vector), and implements `RiskInfo()` on the eight MCP probes:

- `mcptool.Injection` / `SSRF` / `BOLA` / `PathTraversal` / `ResponseLeak`
- `mcptransport.OriginValidation` / `SSESessionHijack`
- `mcpconfig.CredentialExposure`

## Why

The finding write-ups for these probes currently live in a hand-maintained map in the consumer (Guard). Per review feedback, the write-up should live next to the probe so consumers retrieve it (via a `types.RiskDescriber` type assertion) instead of duplicating and drifting. This keeps the security content with the logic it describes and lets Guard/Hadrian/etc. render consistent definitions.

## Notes

- Optional interface, mirroring the existing `ProbeMetadata` pattern — probes that don't implement it are unaffected; consumers fall back to their generic path.
- CVSS vectors are scored **conservatively** (no scope change, tool invocation requires client access `PR:L`, partial/conditional impact as `L`, honest preconditions like `UI:A`/`AT:P`) — a real spread (~5.3 Medium .. 8.7 High) rather than a flat High/Critical cluster.
- Compile-time assertions + per-package tests guard interface conformance and completeness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)