### PR TITLE
chore(ci): bump claude-md-drift pin to v2.16.15 (AGENTS.md-aware) [ENG-5579]

### DIFF
--- a/.github/workflows/claude-md-drift.yml
+++ b/.github/workflows/claude-md-drift.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   drift-check:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-md-drift.yml@2ff4fbf7ed1f20e571eb7f5882ae5d06d092ccaa  # v2.16.8
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-md-drift.yml@34dccb3bc8463c387bdf05d2d7408872325a4416  # v2.16.15
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Bumps the pinned `claude-md-drift.yml` reusable workflow to `34dccb3b` (v2.16.15), which makes drift detection instruction-file aware: `AGENTS.md` is now discovered alongside `CLAUDE.md`, and a `CLAUDE.md` that is exactly the `@AGENTS.md` pointer stub resolves to its sibling `AGENTS.md`. Repos still CLAUDE.md-canonical keep their existing behavior; `skip_extensions` and the caller interface are unchanged (this caller passes only supported inputs/secrets — verified before this bump).

Upstream change: praetorian-inc/public-workflows#151. Part of ENG-5579 (do not auto-close; the ticket tracks the full caller sweep).

This PR's own diff is workflow-YAML only, so the (new) drift check should itself skip via `skip_extensions` — that skip is the expected result, not a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
