### PR TITLE
fix(mcptransport): aggregate OriginValidation bypass variants into one finding (LAB-5584)

### DIFF
--- a/internal/detectors/mcptransport/originvalidation.go
+++ b/internal/detectors/mcptransport/originvalidation.go
@@ -39,10 +39,18 @@ func (d *OriginValidationDetector) Description() string {
 
 // Detect scoring:
 //
-//	baseline                    → 0.0 (informational)
-//	inconclusive flag set       → InconclusiveScore (0.5)
-//	accepted == true            → 1.0 (confirmed weakness)
-//	accepted == false, no flag  → 0.0 (safe)
+//	baseline                       → 0.0 (informational)
+//	inconclusive flag set          → InconclusiveScore (0.5)
+//	accepted == true               → 1.0 / 0.5 by target class
+//	nothing accepted, baseline
+//	  refused by the endpoint      → InconclusiveScore (nothing was assessed)
+//	nothing accepted, baseline
+//	  served                       → 0.0 (safe: the validator really did refuse)
+//
+// The probe reports facts — what was accepted, what was refused, whether the
+// baseline was served — and the classification lives here. That split is why
+// the "the validator is enforced" conclusion cannot be stated for an endpoint
+// that never let us test it.
 //
 // Baseline (no-Origin) acceptance is expected spec-compliant behaviour;
 // surfacing it as a finding would drown real weaknesses. Inconclusive
@@ -80,6 +88,14 @@ func (d *OriginValidationDetector) Detect(_ context.Context, a *attempt.Attempt)
 		default:
 			score = 1.0
 		}
+	case !baselineServed(a):
+		// Nothing was accepted, but the endpoint also refused the plain
+		// no-Origin baseline, so it is refusing the CALLER rather than the
+		// Origin. An auth gate, an IP allowlist and a dead backend are
+		// indistinguishable from Origin enforcement out here, so the refusals
+		// are not evidence a validator exists. Scoring this 0.0 alongside a
+		// genuinely hardened server would report an untested endpoint as clean.
+		score = InconclusiveScore
 	default:
 		return scores, nil
 	}
@@ -90,6 +106,22 @@ func (d *OriginValidationDetector) Detect(_ context.Context, a *attempt.Attempt)
 		scores[i] = score
 	}
 	return scores, nil
+}
+
+// baselineServed reports whether the attempt's endpoint answered the
+// unauthenticated no-Origin baseline, which is what makes a refusal
+// interpretable as Origin enforcement.
+//
+// Attempts that do not carry the fact (the CORS preflight, or a run from
+// before the probe recorded it) are treated as assessable, preserving their
+// previous scoring rather than silently reclassifying them.
+func baselineServed(a *attempt.Attempt) bool {
+	raw, ok := a.GetMetadata(attempt.MetadataKeyOriginValidationBaselineAccepted)
+	if !ok {
+		return true
+	}
+	served, _ := raw.(bool)
+	return served
 }
 
 // stringMeta lives in mcptransport.go (shared with the sibling

--- a/internal/detectors/mcptransport/originvalidation.go
+++ b/internal/detectors/mcptransport/originvalidation.go
@@ -15,10 +15,15 @@ func init() {
 // OriginValidationDetector flags an attempt as vulnerable when the
 // mcptransport.OriginValidation probe recorded that a request a spec-compliant,
 // allowlist-based MCP server would refuse was in fact accepted (or a CORS
-// preflight reflected the attacker Origin with credentials). The probe carries
-// a class label so the reviewer can group findings by concrete validator
-// weakness — an any-origin server (root cause) is a different finding than a
-// case-variant or localhost-lookalike bypass, even though both trip the detector.
+// preflight reflected the attacker Origin with credentials).
+//
+// The probe sends many crafted Origin/Host values but emits ONE scored attempt
+// for the whole sweep (class origin-validation-sweep), so an endpoint that
+// validates nothing produces one finding rather than one per variant. Which
+// variants got through travels as evidence on that attempt — see
+// attempt.MetadataKeyOriginValidationVariants — because an any-origin server
+// is a different remediation than a case-variant-only bypass, even though
+// both trip this detector identically.
 type OriginValidationDetector struct{}
 
 // NewOriginValidationDetector constructs the detector.

--- a/internal/detectors/mcptransport/originvalidation.go
+++ b/internal/detectors/mcptransport/originvalidation.go
@@ -96,6 +96,14 @@ func (d *OriginValidationDetector) Detect(_ context.Context, a *attempt.Attempt)
 		// are not evidence a validator exists. Scoring this 0.0 alongside a
 		// genuinely hardened server would report an untested endpoint as clean.
 		score = InconclusiveScore
+	case len(untestedClasses(a)) > 0:
+		// A whole bypass class got no response at all, so that check never
+		// ran. The endpoint refused everything we managed to send, but one of
+		// the values we could not send might have been the one it accepts —
+		// so "the validator is enforced" is not a conclusion this sweep
+		// earned. Losing SOME variants of an exercised class is ordinary
+		// sampling and the probe does not report it here.
+		score = InconclusiveScore
 	default:
 		return scores, nil
 	}
@@ -122,6 +130,28 @@ func baselineServed(a *attempt.Attempt) bool {
 	}
 	served, _ := raw.(bool)
 	return served
+}
+
+// untestedClasses returns the bypass classes the probe could not test at all.
+// Tolerates the []any shape the value takes after a JSON round-trip.
+func untestedClasses(a *attempt.Attempt) []string {
+	raw, ok := a.GetMetadata(attempt.MetadataKeyOriginValidationUntestedClasses)
+	if !ok {
+		return nil
+	}
+	switch v := raw.(type) {
+	case []string:
+		return v
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
 }
 
 // stringMeta lives in mcptransport.go (shared with the sibling

--- a/internal/detectors/mcptransport/originvalidation_test.go
+++ b/internal/detectors/mcptransport/originvalidation_test.go
@@ -74,6 +74,48 @@ func TestOriginValidationDetector(t *testing.T) {
 		})
 	}
 
+	// Baseline-served is what makes a refusal interpretable. A sweep that
+	// accepted nothing is only "safe" when the endpoint actually answered the
+	// unauthenticated baseline; if it refused that too, it refused the CALLER
+	// and the sweep assessed nothing. Scoring both 0.0 would report an
+	// untested endpoint as clean.
+	baselineTests := []struct {
+		name             string
+		baselineAccepted any
+		wantScore        float64
+	}{
+		{"baseline served → refusals are real, safe", true, 0.0},
+		{"baseline refused → nothing was assessed, inconclusive", false, InconclusiveScore},
+	}
+	for _, tt := range baselineTests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := originValidationAttempt("origin-validation-sweep", false, "0 of 9 accepted")
+			a.Metadata[attempt.MetadataKeyOriginValidationTargetClass] = "loopback"
+			a.Metadata[attempt.MetadataKeyOriginValidationBaselineAccepted] = tt.baselineAccepted
+			got, err := d.Detect(context.Background(), a)
+			if err != nil {
+				t.Fatalf("Detect: %v", err)
+			}
+			if len(got) != 1 || got[0] != tt.wantScore {
+				t.Errorf("Detect = %v, want [%v]", got, tt.wantScore)
+			}
+		})
+	}
+
+	// An attempt that does not carry the baseline fact (the CORS preflight, or
+	// a run predating it) keeps its previous scoring rather than being
+	// silently reclassified as inconclusive.
+	t.Run("no baseline fact → unchanged", func(t *testing.T) {
+		a := originValidationAttempt("cors-reflect-creds", false, "HTTP 204")
+		got, err := d.Detect(context.Background(), a)
+		if err != nil {
+			t.Fatalf("Detect: %v", err)
+		}
+		if len(got) != 1 || got[0] != 0.0 {
+			t.Errorf("Detect = %v, want [0]", got)
+		}
+	})
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := d.Detect(context.Background(), tt.a)

--- a/internal/detectors/mcptransport/originvalidation_test.go
+++ b/internal/detectors/mcptransport/originvalidation_test.go
@@ -102,6 +102,36 @@ func TestOriginValidationDetector(t *testing.T) {
 		})
 	}
 
+	// A wholly untested bypass class means that check never ran, so a sweep
+	// that accepted nothing has not established enforcement. This scoring
+	// moved here from the probe, which used to force an error status to make
+	// the row non-passing — the probe now reports the fact and the detector
+	// classifies it.
+	untestedTests := []struct {
+		name      string
+		untested  any
+		wantScore float64
+	}{
+		{"no untested class → safe", []string{}, 0.0},
+		{"a class never ran → inconclusive", []string{"unexpected-host"}, InconclusiveScore},
+		{"JSON round-tripped []any → inconclusive", []any{"null-origin"}, InconclusiveScore},
+	}
+	for _, tt := range untestedTests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := originValidationAttempt("origin-validation-sweep", false, "0 of 9 accepted")
+			a.Metadata[attempt.MetadataKeyOriginValidationTargetClass] = "loopback"
+			a.Metadata[attempt.MetadataKeyOriginValidationBaselineAccepted] = true
+			a.Metadata[attempt.MetadataKeyOriginValidationUntestedClasses] = tt.untested
+			got, err := d.Detect(context.Background(), a)
+			if err != nil {
+				t.Fatalf("Detect: %v", err)
+			}
+			if len(got) != 1 || got[0] != tt.wantScore {
+				t.Errorf("Detect = %v, want [%v]", got, tt.wantScore)
+			}
+		})
+	}
+
 	// An attempt that does not carry the baseline fact (the CORS preflight, or
 	// a run predating it) keeps its previous scoring rather than being
 	// silently reclassified as inconclusive.

--- a/internal/detectors/mcptransport/originvalidation_test.go
+++ b/internal/detectors/mcptransport/originvalidation_test.go
@@ -33,16 +33,15 @@ func TestOriginValidationDetector(t *testing.T) {
 		a    *attempt.Attempt
 		want []float64
 	}{
-		{"external-origin accepted -> vuln", originValidationAttempt("external-origin", true, "HTTP 200"), []float64{1.0}},
-		{"null-origin accepted -> vuln", originValidationAttempt("null-origin", true, "HTTP 200"), []float64{1.0}},
-		{"extension-origin accepted -> vuln", originValidationAttempt("extension-origin", true, "HTTP 200"), []float64{1.0}},
-		{"localhost-lookalike accepted -> vuln", originValidationAttempt("localhost-lookalike", true, "HTTP 200"), []float64{1.0}},
-		{"case-variant accepted -> vuln", originValidationAttempt("case-variant", true, "HTTP 200"), []float64{1.0}},
-		{"unexpected-host accepted -> vuln", originValidationAttempt("unexpected-host", true, "HTTP 200"), []float64{1.0}},
+		// The sweep is the probe's aggregated bypass attempt: one output
+		// carrying every accepted variant as evidence, so it scores exactly
+		// one 1.0 — one finding for the endpoint, not one per variant
+		// (LAB-5584).
+		{"sweep accepted -> one vuln score", originValidationAttempt("origin-validation-sweep", true, "7 of 9 accepted"), []float64{1.0}},
+		{"sweep rejected -> safe", originValidationAttempt("origin-validation-sweep", false, "0 of 9 accepted"), []float64{0.0}},
 		{"cors-reflect-creds accepted -> vuln", originValidationAttempt("cors-reflect-creds", true, "HTTP 204"), []float64{1.0}},
 		{"baseline accepted -> not a finding", originValidationAttempt("baseline", true, "HTTP 200"), []float64{0.0}},
-		{"external-origin rejected -> safe", originValidationAttempt("external-origin", false, "HTTP 403"), []float64{0.0}},
-		{"blind acceptance (no output) still flagged", originValidationAttempt("external-origin", true, ""), []float64{1.0}},
+		{"blind acceptance (no output) still flagged", originValidationAttempt("origin-validation-sweep", true, ""), []float64{1.0}},
 	}
 
 	d := newOriginValidationDetector(t)
@@ -63,7 +62,7 @@ func TestOriginValidationDetector(t *testing.T) {
 	}
 	for _, tt := range targetTests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := originValidationAttempt("external-origin", true, "HTTP 200")
+			a := originValidationAttempt("origin-validation-sweep", true, "7 of 9 accepted")
 			a.Metadata[attempt.MetadataKeyOriginValidationTargetClass] = tt.targetClass
 			got, err := d.Detect(context.Background(), a)
 			if err != nil {

--- a/internal/probes/mcptransport/originvalidation.go
+++ b/internal/probes/mcptransport/originvalidation.go
@@ -175,7 +175,7 @@ func (p *OriginValidation) RiskInfo() types.RiskInfo {
 		Taxonomies:     "- cwe: 346\n- cwe: 350\n- cwe: 942",
 		CVSSVector:     "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:A/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N",
 		Verification: "## How this is confirmed\n\n" +
-			"Augustus sends requests carrying a foreign `Origin` (and `Host`) header that a specification-compliant MCP server must reject, and observes the endpoint accept them. Because the endpoint binds a loopback or private-network address, this is the precondition for a browser DNS-rebinding attack (CVE-2025-49596 class). On a loopback / RFC1918 target the finding is scored full; on a public endpoint the same wire result is CSRF-class and scored inconclusive, since exploitability depends on cookie/auth context the probe cannot inspect.\n\n" +
+			"Augustus sends a sweep of requests carrying foreign `Origin` (and `Host`) header values that a specification-compliant MCP server must reject, and observes the endpoint accept them. The whole sweep is reported as a single finding for the endpoint — every crafted value it accepted is listed in the evidence, since which ones get through is what distinguishes an endpoint with no validation from one whose allowlist is merely weak. Because the endpoint binds a loopback or private-network address, this is the precondition for a browser DNS-rebinding attack (CVE-2025-49596 class). On a loopback / RFC1918 target the finding is scored full; on a public endpoint the same wire result is CSRF-class and scored inconclusive, since exploitability depends on cookie/auth context the probe cannot inspect.\n\n" +
 			"## Reproduce\n\n" +
 			"Re-run the `mcptransport.OriginValidation` probe against the affected endpoint via the `mcp.MCP` generator. The endpoint returns a success response to a request bearing a foreign Origin/Host it should have rejected.",
 	}
@@ -195,12 +195,20 @@ func (p *OriginValidation) GetPrompts() []string {
 	return []string{"Randomised MCP initialize + CORS preflight bearing Origin/Host values a rebinding-protected server should refuse"}
 }
 
-// originValidationClass is a stable classifier for a bypass, so a report can group
-// findings by concrete validator weakness rather than one lumped verdict.
+// originValidationClass is a stable classifier for a bypass. classBaseline,
+// classSweep and classCORSReflectCreds label whole attempts; the rest label
+// individual crafted values *inside* the sweep attempt's variant list.
+//
+// The per-variant classes were once attempt classes too, one attempt each.
+// That reported a single flaw as ten findings: a server that validates
+// nothing accepts every variant, so ten identical 1.0 rows drowned every
+// other result in an MCP scan (LAB-5584). They are ten proofs of one
+// property, and they now travel as evidence on one finding.
 type originValidationClass string
 
 const (
 	classBaseline           originValidationClass = "baseline"
+	classSweep              originValidationClass = "origin-validation-sweep"
 	classExternalOrigin     originValidationClass = "external-origin"
 	classNullOrigin         originValidationClass = "null-origin"
 	classExtensionOrigin    originValidationClass = "extension-origin"
@@ -363,15 +371,21 @@ func (p *OriginValidation) Probe(ctx context.Context, gen types.Generator) ([]*a
 	// we can't distinguish "server rejected our headers" from "server can't
 	// accept us at all," so the whole sweep is inconclusive. We record the
 	// attempt either way.
-	base := stampClass(p.probeAccess(ctx, client, endpoint, transport, "", "", classBaseline))
+	base := stampClass(p.attemptFromVariant(p.sendVariant(ctx, client, endpoint, transport, "", "", classBaseline)))
 	attempts = append(attempts, base)
 	if !metaBool(base, attempt.MetadataKeyOriginValidationAccepted) {
 		slog.Info("mcptransport.OriginValidation: baseline (no Origin) not accepted; downstream bypass results may be inconclusive", "endpoint", endpoint, "transport", transport)
 	}
 
+	// 2-4. The bypass sweep. Every variant below asks the SAME question — does
+	// this endpoint enforce the Origin/Host allowlist the spec requires — so
+	// the results are collected here and folded into a single finding after
+	// the preflight, rather than emitted one attempt per variant (LAB-5584).
+	var variants []variantResult
+
 	// 2. Origin bypass sweep.
 	for _, o := range p.buildOriginPayloads() {
-		attempts = append(attempts, stampClass(p.probeAccess(ctx, client, endpoint, transport, o.value, "", o.class)))
+		variants = append(variants, p.sendVariant(ctx, client, endpoint, transport, o.value, "", o.class))
 	}
 
 	// 3. Case-variant of the expected host — tests case-sensitive vs
@@ -386,23 +400,206 @@ func (p *OriginValidation) Probe(ctx context.Context, gen types.Generator) ([]*a
 	if u.Host != "" {
 		caseHost := swapCase(u.Host)
 		if caseHost != u.Host {
-			attempts = append(attempts, stampClass(p.probeAccess(ctx, client, endpoint, transport, "http://"+caseHost, "", classCaseVariant)))
+			variants = append(variants, p.sendVariant(ctx, client, endpoint, transport, "http://"+caseHost, "", classCaseVariant))
 		}
 	}
 
 	// 4. Host header sweep.
 	for _, h := range p.buildHostPayloads() {
-		attempts = append(attempts, stampClass(p.probeAccess(ctx, client, endpoint, transport, "", h.value, h.class)))
+		variants = append(variants, p.sendVariant(ctx, client, endpoint, transport, "", h.value, h.class))
 	}
 
 	// 5. CORS preflight — OPTIONS with an external Origin, inspect
 	// Access-Control-Allow-Origin echo + Allow-Credentials. A server that
 	// reflects the attacker Origin with credentials is exploitable regardless
 	// of whether the POST body succeeds, because a browser DNS-rebinding
-	// attacker can read the response.
-	attempts = append(attempts, stampClass(p.probePreflight(ctx, client, endpoint, "https://"+p.nonce[:8]+".example.org", u.Host)))
+	// attacker can read the response. Sent before the sweep is aggregated so
+	// its outcome can escalate the aggregated finding's stated impact.
+	preflight := stampClass(p.probePreflight(ctx, client, endpoint, "https://"+p.nonce[:8]+".example.org", u.Host))
+	credentialedRead := metaBool(preflight, attempt.MetadataKeyOriginValidationAccepted)
+
+	// 6. One finding for the endpoint, carrying every variant as evidence.
+	if agg := p.aggregateSweep(endpoint, transport, variants, credentialedRead); agg != nil {
+		attempts = append(attempts, stampClass(agg))
+	}
+	attempts = append(attempts, preflight)
 
 	return attempts, nil
+}
+
+// variantResult is the outcome of one crafted Origin/Host value. The sweep
+// collects these rather than emitting an attempt each, because ten variants
+// are ten proofs of one property and a server that validates nothing answers
+// all ten identically — see the originValidationClass doc comment.
+type variantResult struct {
+	class    originValidationClass
+	origin   string
+	host     string
+	accepted bool
+	// transcript is the full request/response record, including the response
+	// body (streamable-HTTP only). Carried on the baseline attempt as its
+	// output, and on the aggregate for one representative accepted variant.
+	transcript string
+	// result is the one-line response summary shown in the aggregated
+	// evidence table, or the transport error when the request never landed.
+	result string
+	err    error
+}
+
+// aggregateSweep folds the whole bypass sweep into the single scored attempt
+// for this endpoint. Returns nil when the sweep sent nothing (no variants
+// were applicable), so callers don't emit an empty finding.
+//
+// The attempt scores through the ordinary detector path: class is not
+// "baseline", and the accepted flag is true when ANY variant was accepted.
+// The target-class severity tiering is untouched — the caller stamps it on
+// this attempt exactly as it does on every other.
+func (p *OriginValidation) aggregateSweep(endpoint, transport string, variants []variantResult, credentialedRead bool) *attempt.Attempt {
+	if len(variants) == 0 {
+		return nil
+	}
+
+	var (
+		accepted       []variantResult
+		rejected       []variantResult
+		errored        []variantResult
+		acceptedClass  []string
+		seenClass      = map[originValidationClass]bool{}
+		variantDetails = make([]map[string]any, 0, len(variants))
+	)
+	for _, v := range variants {
+		detail := map[string]any{
+			"class":    string(v.class),
+			"accepted": v.accepted,
+			"result":   v.result,
+		}
+		if v.origin != "" {
+			detail["origin"] = v.origin
+		}
+		if v.host != "" {
+			detail["host"] = v.host
+		}
+		variantDetails = append(variantDetails, detail)
+
+		switch {
+		case v.err != nil:
+			errored = append(errored, v)
+		case v.accepted:
+			accepted = append(accepted, v)
+			if !seenClass[v.class] {
+				seenClass[v.class] = true
+				acceptedClass = append(acceptedClass, string(v.class))
+			}
+		default:
+			rejected = append(rejected, v)
+		}
+	}
+
+	a := attempt.New(describeSweep(len(accepted), len(variants)))
+	a.Probe = p.Name()
+	a.Detector = p.GetPrimaryDetector()
+	a.Metadata[attempt.MetadataKeyOriginValidationClass] = string(classSweep)
+	a.Metadata[attempt.MetadataKeyOriginValidationVariants] = variantDetails
+	a.Metadata[attempt.MetadataKeyOriginValidationAcceptedClasses] = acceptedClass
+	a.Metadata[attempt.MetadataKeyOriginValidationVariantsSent] = len(variants)
+	a.Metadata[attempt.MetadataKeyOriginValidationVariantsAccepted] = len(accepted)
+	a.Metadata[attempt.MetadataKeyOriginValidationCredentialedRead] = credentialedRead
+	a.AddOutput(renderSweepEvidence(endpoint, transport, accepted, rejected, errored, credentialedRead))
+
+	// Every variant failed at the transport — the endpoint was never actually
+	// tested. Reporting that as SAFE would hide a broken scan behind a green
+	// row, so it surfaces as an errored attempt with no accept/reject verdict.
+	if len(errored) == len(variants) {
+		a.SetError(fmt.Errorf("all %d Origin/Host variants failed in transit; first error: %w", len(variants), errored[0].err))
+		return a
+	}
+
+	a.Complete()
+	a.Metadata[attempt.MetadataKeyOriginValidationAccepted] = len(accepted) > 0
+	return a
+}
+
+// describeSweep renders the aggregated attempt's label.
+func describeSweep(accepted, total int) string {
+	return fmt.Sprintf("[%s] %d of %d crafted Origin/Host values accepted", classSweep, accepted, total)
+}
+
+// renderSweepEvidence builds the aggregated finding's evidence: the verdict on
+// the validator, which variants got through, and — when the preflight found
+// credentialed reflection — the escalation from "drive the tool surface blind"
+// to "also read the responses".
+//
+// Which variants pass is the actionable half for a remediator: an accepted
+// case-variant alone means the allowlist exists but compares case-sensitively,
+// which is a different fix from an endpoint that accepts any origin at all.
+func renderSweepEvidence(endpoint, transport string, accepted, rejected, errored []variantResult, credentialedRead bool) string {
+	var b strings.Builder
+	total := len(accepted) + len(rejected) + len(errored)
+
+	fmt.Fprintf(&b, "MCP Origin/Host validation sweep against %s (%s transport)\n", endpoint, transport)
+	fmt.Fprintf(&b, "%d of %d crafted Origin/Host values were accepted. A spec-compliant\n", len(accepted), total)
+	fmt.Fprintf(&b, "allowlist validator would have refused all %d.\n\n", total)
+
+	fmt.Fprintf(&b, "Validator verdict: %s\n\n", validatorVerdict(len(accepted), len(rejected), len(errored)))
+
+	writeBucket(&b, "ACCEPTED — served a request it should have refused", accepted)
+	writeBucket(&b, "REJECTED — refused as a hardened server should", rejected)
+	writeBucket(&b, "NOT TESTED — request failed in transit", errored)
+
+	if credentialedRead {
+		b.WriteString("Credentialed CORS reflection: PRESENT. The endpoint reflects the attacker's\n" +
+			"Origin into Access-Control-Allow-Origin alongside Access-Control-Allow-Credentials,\n" +
+			"so a rebound page does not merely drive the tool surface blind — it can also READ\n" +
+			"the responses, turning this into a cross-origin data-disclosure primitive.\n")
+	} else {
+		b.WriteString("Credentialed CORS reflection: absent. A rebound page can drive the tool surface\n" +
+			"but cannot read the responses from its own origin.\n")
+	}
+
+	// One full transcript as proof; the per-variant lines above already carry
+	// the discriminating detail, and ten 8 KB bodies would bury it.
+	if len(accepted) > 0 && accepted[0].transcript != "" {
+		fmt.Fprintf(&b, "\nRepresentative accepted exchange (%s):\n%s\n", variantLabel(accepted[0]), accepted[0].transcript)
+	}
+	return b.String()
+}
+
+// validatorVerdict states what the accept/reject split means about the
+// server's validator, which is the thing a remediator acts on.
+func validatorVerdict(accepted, rejected, errored int) string {
+	switch {
+	case accepted == 0 && rejected > 0:
+		return "every crafted value was refused — Origin/Host validation is enforced"
+	case accepted == 0:
+		return "no variant was accepted, but none completed cleanly either — inconclusive"
+	case rejected == 0 && errored == 0:
+		return "NO Origin/Host validation is enforced — every crafted value was accepted"
+	default:
+		return "validation is PARTIAL — the accepted classes below are the checks that are missing"
+	}
+}
+
+// writeBucket renders one accept/reject/error group, skipping empty ones.
+func writeBucket(b *strings.Builder, heading string, vs []variantResult) {
+	if len(vs) == 0 {
+		return
+	}
+	b.WriteString(heading + "\n")
+	width := 0
+	for _, v := range vs {
+		if n := len(variantLabel(v)); n > width {
+			width = n
+		}
+	}
+	for _, v := range vs {
+		fmt.Fprintf(b, "  %-*s  -> %s\n", width, variantLabel(v), v.result)
+	}
+	b.WriteString("\n")
+}
+
+// variantLabel renders "[class] Origin=... Host=..." for the evidence table.
+func variantLabel(v variantResult) string {
+	return describeAttempt(v.origin, v.host, v.class)
 }
 
 // resolveEndpoint returns the endpoint URL from probe config (explicit
@@ -417,25 +614,19 @@ func (p *OriginValidation) resolveEndpoint(gen types.Generator) string {
 	return ""
 }
 
-// probeAccess sends the transport-appropriate request (POST initialize for
+// sendVariant sends the transport-appropriate request (POST initialize for
 // streamable HTTP; GET /sse for legacy SSE) bearing the crafted Origin/Host
-// headers, classifies the response, and returns the attempt. Empty origin /
-// host means "leave unset" (baseline shape). The security question — did the
-// server serve this request from an untrusted caller — is answered by the
-// SAME defensive middleware regardless of what payload follows: Origin/Host
-// validation runs before either handler.
-func (p *OriginValidation) probeAccess(ctx context.Context, client *http.Client, endpoint, transport, origin, host string, class originValidationClass) *attempt.Attempt {
-	label := describeAttempt(origin, host, class)
-	a := attempt.New(label)
-	a.Probe = p.Name()
-	a.Detector = p.GetPrimaryDetector()
-	a.Metadata[attempt.MetadataKeyOriginValidationClass] = string(class)
-	if origin != "" {
-		a.Metadata[attempt.MetadataKeyOriginValidationOrigin] = origin
-	}
-	if host != "" {
-		a.Metadata[attempt.MetadataKeyOriginValidationHost] = host
-	}
+// headers and classifies the response. Empty origin / host means "leave unset"
+// (baseline shape). The security question — did the server serve this request
+// from an untrusted caller — is answered by the SAME defensive middleware
+// regardless of what payload follows: Origin/Host validation runs before
+// either handler.
+//
+// Returns a plain result rather than an attempt so the caller decides what
+// becomes a finding: the baseline gets its own attempt, while the bypass
+// variants are folded into one (see aggregateSweep).
+func (p *OriginValidation) sendVariant(ctx context.Context, client *http.Client, endpoint, transport, origin, host string, class originValidationClass) variantResult {
+	v := variantResult{class: class, origin: origin, host: host}
 
 	var (
 		req    *http.Request
@@ -456,8 +647,7 @@ func (p *OriginValidation) probeAccess(ctx context.Context, client *http.Client,
 		method = "POST"
 	}
 	if err != nil {
-		a.SetError(err)
-		return a
+		return v.fail(err)
 	}
 	// Set method-specific headers AFTER the nil check so both branches share
 	// the same guard (previously the SSE branch touched req before the check,
@@ -487,8 +677,7 @@ func (p *OriginValidation) probeAccess(ctx context.Context, client *http.Client,
 		if transport == "sse" && resp != nil {
 			// Fall through to classify below.
 		} else {
-			a.SetError(fmt.Errorf("%s %s: %w", method, endpoint, err))
-			return a
+			return v.fail(fmt.Errorf("%s %s: %w", method, endpoint, err))
 		}
 	}
 	defer func() {
@@ -514,16 +703,57 @@ func (p *OriginValidation) probeAccess(ctx context.Context, client *http.Client,
 			body, _ = io.ReadAll(io.LimitReader(resp.Body, 8*1024))
 		}
 	}
-	a.AddOutput(fmt.Sprintf("%s %s -> HTTP %d\nContent-Type: %s\n%s", method, endpoint, status, contentType, string(body)))
-	a.Complete()
+	v.transcript = fmt.Sprintf("%s %s -> HTTP %d\nContent-Type: %s\n%s", method, endpoint, status, contentType, string(body))
+	v.result = fmt.Sprintf("HTTP %d, %s", status, contentTypeOrNone(contentType))
 
-	var accepted bool
 	if transport == "sse" {
-		accepted = serverStartedSSEStream(status, contentType)
+		v.accepted = serverStartedSSEStream(status, contentType)
 	} else {
-		accepted = serverProcessedInitialize(status, contentType, body)
+		v.accepted = serverProcessedInitialize(status, contentType, body)
 	}
-	a.Metadata[attempt.MetadataKeyOriginValidationAccepted] = accepted
+	return v
+}
+
+// fail records a transport-level failure on the variant. The request never
+// reached the validator, so the variant is neither accepted nor rejected —
+// aggregateSweep reports it as NOT TESTED rather than folding it into either
+// verdict.
+func (v variantResult) fail(err error) variantResult {
+	v.err = err
+	v.result = err.Error()
+	return v
+}
+
+// contentTypeOrNone keeps the evidence table readable when a server answers
+// with no Content-Type at all.
+func contentTypeOrNone(ct string) string {
+	if ct == "" {
+		return "(no content-type)"
+	}
+	return ct
+}
+
+// attemptFromVariant renders a variant as a standalone scored attempt. Only
+// the baseline (no-Origin) probe takes this path; the bypass variants are
+// aggregated into one attempt instead — see aggregateSweep.
+func (p *OriginValidation) attemptFromVariant(v variantResult) *attempt.Attempt {
+	a := attempt.New(variantLabel(v))
+	a.Probe = p.Name()
+	a.Detector = p.GetPrimaryDetector()
+	a.Metadata[attempt.MetadataKeyOriginValidationClass] = string(v.class)
+	if v.origin != "" {
+		a.Metadata[attempt.MetadataKeyOriginValidationOrigin] = v.origin
+	}
+	if v.host != "" {
+		a.Metadata[attempt.MetadataKeyOriginValidationHost] = v.host
+	}
+	if v.err != nil {
+		a.SetError(v.err)
+		return a
+	}
+	a.AddOutput(v.transcript)
+	a.Complete()
+	a.Metadata[attempt.MetadataKeyOriginValidationAccepted] = v.accepted
 	return a
 }
 

--- a/internal/probes/mcptransport/originvalidation.go
+++ b/internal/probes/mcptransport/originvalidation.go
@@ -445,6 +445,30 @@ type variantResult struct {
 	err    error
 }
 
+// Variant outcomes carried in the aggregated finding's evidence. "accepted"
+// and "refused" are both observations the probe made; "not-tested" is the
+// absence of one. They must stay distinct for the same reason corsReflection
+// is a tri-state rather than a bool: a consumer reading accepted==false could
+// not tell "the server refused this value" from "we never found out", and the
+// second is not evidence of validation.
+const (
+	variantAccepted  = "accepted"
+	variantRefused   = "refused"
+	variantNotTested = "not-tested"
+)
+
+// outcome collapses the variant to the tri-state recorded in the evidence.
+func (v variantResult) outcome() string {
+	switch {
+	case v.err != nil:
+		return variantNotTested
+	case v.accepted:
+		return variantAccepted
+	default:
+		return variantRefused
+	}
+}
+
 // corsReflection is the tri-state outcome of the credentialed-CORS preflight.
 // "Not tested" must stay distinct from "absent": a preflight that never
 // completed tells us nothing about the endpoint, and reporting that as an
@@ -492,9 +516,9 @@ func (p *OriginValidation) aggregateSweep(endpoint, transport string, variants [
 	)
 	for _, v := range variants {
 		detail := map[string]any{
-			"class":    string(v.class),
-			"accepted": v.accepted,
-			"result":   v.result,
+			"class":   string(v.class),
+			"outcome": v.outcome(),
+			"result":  v.result,
 		}
 		if v.origin != "" {
 			detail["origin"] = v.origin
@@ -504,10 +528,10 @@ func (p *OriginValidation) aggregateSweep(endpoint, transport string, variants [
 		}
 		variantDetails = append(variantDetails, detail)
 
-		switch {
-		case v.err != nil:
+		switch v.outcome() {
+		case variantNotTested:
 			errored = append(errored, v)
-		case v.accepted:
+		case variantAccepted:
 			accepted = append(accepted, v)
 			if !seenClass[v.class] {
 				seenClass[v.class] = true

--- a/internal/probes/mcptransport/originvalidation.go
+++ b/internal/probes/mcptransport/originvalidation.go
@@ -416,10 +416,9 @@ func (p *OriginValidation) Probe(ctx context.Context, gen types.Generator) ([]*a
 	// attacker can read the response. Sent before the sweep is aggregated so
 	// its outcome can escalate the aggregated finding's stated impact.
 	preflight := stampClass(p.probePreflight(ctx, client, endpoint, "https://"+p.nonce[:8]+".example.org", u.Host))
-	credentialedRead := metaBool(preflight, attempt.MetadataKeyOriginValidationAccepted)
 
 	// 6. One finding for the endpoint, carrying every variant as evidence.
-	if agg := p.aggregateSweep(endpoint, transport, variants, credentialedRead); agg != nil {
+	if agg := p.aggregateSweep(endpoint, transport, variants, corsResultFrom(preflight)); agg != nil {
 		attempts = append(attempts, stampClass(agg))
 	}
 	attempts = append(attempts, preflight)
@@ -446,6 +445,30 @@ type variantResult struct {
 	err    error
 }
 
+// corsReflection is the tri-state outcome of the credentialed-CORS preflight.
+// "Not tested" must stay distinct from "absent": a preflight that never
+// completed tells us nothing about the endpoint, and reporting that as an
+// absence understates the aggregated finding's impact.
+type corsReflection int
+
+const (
+	corsNotTested corsReflection = iota
+	corsAbsent
+	corsPresent
+)
+
+// corsResultFrom derives the tri-state from the preflight attempt. An errored
+// preflight is "not tested", NOT "no reflection".
+func corsResultFrom(preflight *attempt.Attempt) corsReflection {
+	if preflight == nil || preflight.Status == attempt.StatusError {
+		return corsNotTested
+	}
+	if metaBool(preflight, attempt.MetadataKeyOriginValidationAccepted) {
+		return corsPresent
+	}
+	return corsAbsent
+}
+
 // aggregateSweep folds the whole bypass sweep into the single scored attempt
 // for this endpoint. Returns nil when the sweep sent nothing (no variants
 // were applicable), so callers don't emit an empty finding.
@@ -454,7 +477,7 @@ type variantResult struct {
 // "baseline", and the accepted flag is true when ANY variant was accepted.
 // The target-class severity tiering is untouched — the caller stamps it on
 // this attempt exactly as it does on every other.
-func (p *OriginValidation) aggregateSweep(endpoint, transport string, variants []variantResult, credentialedRead bool) *attempt.Attempt {
+func (p *OriginValidation) aggregateSweep(endpoint, transport string, variants []variantResult, cors corsReflection) *attempt.Attempt {
 	if len(variants) == 0 {
 		return nil
 	}
@@ -503,8 +526,14 @@ func (p *OriginValidation) aggregateSweep(endpoint, transport string, variants [
 	a.Metadata[attempt.MetadataKeyOriginValidationAcceptedClasses] = acceptedClass
 	a.Metadata[attempt.MetadataKeyOriginValidationVariantsSent] = len(variants)
 	a.Metadata[attempt.MetadataKeyOriginValidationVariantsAccepted] = len(accepted)
-	a.Metadata[attempt.MetadataKeyOriginValidationCredentialedRead] = credentialedRead
-	a.AddOutput(renderSweepEvidence(endpoint, transport, accepted, rejected, errored, credentialedRead))
+	// Only claim a credentialed-read verdict when the preflight actually ran.
+	// Recording false for an untested preflight would assert an absence we
+	// never observed.
+	if cors != corsNotTested {
+		a.Metadata[attempt.MetadataKeyOriginValidationCredentialedRead] = cors == corsPresent
+	}
+	untested := untestedClasses(variants)
+	a.AddOutput(renderSweepEvidence(endpoint, transport, accepted, rejected, errored, cors, untested))
 
 	// Every variant failed at the transport — the endpoint was never actually
 	// tested. Reporting that as SAFE would hide a broken scan behind a green
@@ -516,7 +545,54 @@ func (p *OriginValidation) aggregateSweep(endpoint, transport string, variants [
 
 	a.Complete()
 	a.Metadata[attempt.MetadataKeyOriginValidationAccepted] = len(accepted) > 0
+
+	// A whole bypass class went untested — every variant of it died in
+	// transit — and nothing else was accepted. That is a check this sweep
+	// never ran, not merely a lost sample, so "the endpoint refused
+	// everything" is a conclusion it did not earn. Mark it inconclusive,
+	// matching how the sibling SSESessionHijack probe flags a determination
+	// it could not make.
+	//
+	// Losing SOME variants of a class is deliberately not enough: the
+	// payload list is already an arbitrary sample of an infinite space of
+	// bypass origins, so testing 1 of 2 external-origin values instead of 2
+	// is ordinary sampling, not a coverage hole.
+	//
+	// Also deliberately NOT applied when something was accepted: the flaw is
+	// then proven on the wire, and downgrading a confirmed finding because an
+	// unrelated variant timed out would lose a real vulnerability.
+	if len(accepted) == 0 && len(untested) > 0 {
+		a.Metadata[attempt.MetadataKeyInconclusive] = true
+		a.Metadata[attempt.MetadataKeyInconclusiveReason] = fmt.Sprintf(
+			"no %s variant completed, so that check never ran; every class that did run was refused",
+			strings.Join(untested, ", "))
+	}
 	return a
+}
+
+// untestedClasses returns the bypass classes for which NOT ONE variant got a
+// response, in sweep order. Those are checks that never ran — distinct from a
+// class that was exercised and merely lost a sample to a flaky connection.
+func untestedClasses(variants []variantResult) []string {
+	total := map[originValidationClass]int{}
+	failed := map[originValidationClass]int{}
+	var order []originValidationClass
+	for _, v := range variants {
+		if total[v.class] == 0 {
+			order = append(order, v.class)
+		}
+		total[v.class]++
+		if v.err != nil {
+			failed[v.class]++
+		}
+	}
+	var out []string
+	for _, c := range order {
+		if failed[c] == total[c] {
+			out = append(out, string(c))
+		}
+	}
+	return out
 }
 
 // describeSweep renders the aggregated attempt's label.
@@ -532,7 +608,7 @@ func describeSweep(accepted, total int) string {
 // Which variants pass is the actionable half for a remediator: an accepted
 // case-variant alone means the allowlist exists but compares case-sensitively,
 // which is a different fix from an endpoint that accepts any origin at all.
-func renderSweepEvidence(endpoint, transport string, accepted, rejected, errored []variantResult, credentialedRead bool) string {
+func renderSweepEvidence(endpoint, transport string, accepted, rejected, errored []variantResult, cors corsReflection, untested []string) string {
 	var b strings.Builder
 	total := len(accepted) + len(rejected) + len(errored)
 
@@ -540,20 +616,25 @@ func renderSweepEvidence(endpoint, transport string, accepted, rejected, errored
 	fmt.Fprintf(&b, "%d of %d crafted Origin/Host values were accepted. A spec-compliant\n", len(accepted), total)
 	fmt.Fprintf(&b, "allowlist validator would have refused all %d.\n\n", total)
 
-	fmt.Fprintf(&b, "Validator verdict: %s\n\n", validatorVerdict(len(accepted), len(rejected), len(errored)))
+	fmt.Fprintf(&b, "Validator verdict: %s\n\n", validatorVerdict(len(accepted), len(rejected), len(errored), untested))
 
 	writeBucket(&b, "ACCEPTED — served a request it should have refused", accepted)
 	writeBucket(&b, "REJECTED — refused as a hardened server should", rejected)
 	writeBucket(&b, "NOT TESTED — request failed in transit", errored)
 
-	if credentialedRead {
+	switch cors {
+	case corsPresent:
 		b.WriteString("Credentialed CORS reflection: PRESENT. The endpoint reflects the attacker's\n" +
 			"Origin into Access-Control-Allow-Origin alongside Access-Control-Allow-Credentials,\n" +
 			"so a rebound page does not merely drive the tool surface blind — it can also READ\n" +
 			"the responses, turning this into a cross-origin data-disclosure primitive.\n")
-	} else {
+	case corsAbsent:
 		b.WriteString("Credentialed CORS reflection: absent. A rebound page can drive the tool surface\n" +
 			"but cannot read the responses from its own origin.\n")
+	default:
+		b.WriteString("Credentialed CORS reflection: NOT TESTED — the preflight request did not\n" +
+			"complete. Whether a rebound page could also read the responses is unknown;\n" +
+			"re-run against a reachable endpoint before treating that as ruled out.\n")
 	}
 
 	// One full transcript as proof; the per-variant lines above already carry
@@ -566,14 +647,27 @@ func renderSweepEvidence(endpoint, transport string, accepted, rejected, errored
 
 // validatorVerdict states what the accept/reject split means about the
 // server's validator, which is the thing a remediator acts on.
-func validatorVerdict(accepted, rejected, errored int) string {
+//
+// A class with no completed variant is a check that never ran, so a verdict
+// drawn over one says so: "we refused every check we managed to run" is a
+// materially weaker claim than "we refused everything", and the verdict line
+// is the sentence a reader takes away. Losing some variants of an
+// otherwise-exercised class is ordinary sampling and only warrants a
+// parenthetical.
+func validatorVerdict(accepted, rejected, errored int, untested []string) string {
 	switch {
-	case accepted == 0 && rejected > 0:
-		return "every crafted value was refused — Origin/Host validation is enforced"
+	case accepted == 0 && rejected == 0:
+		return fmt.Sprintf("nothing was tested — all %d variants failed in transit", errored)
+	case accepted == 0 && len(untested) > 0:
+		return fmt.Sprintf("every check that ran was refused, but no %s variant completed — that check never ran, so validation cannot be called enforced", strings.Join(untested, " / "))
+	case accepted == 0 && errored > 0:
+		return fmt.Sprintf("every crafted value that landed was refused — Origin/Host validation is enforced (%d variants did not complete, but every check class was still exercised)", errored)
 	case accepted == 0:
-		return "no variant was accepted, but none completed cleanly either — inconclusive"
+		return "every crafted value was refused — Origin/Host validation is enforced"
 	case rejected == 0 && errored == 0:
 		return "NO Origin/Host validation is enforced — every crafted value was accepted"
+	case errored > 0:
+		return fmt.Sprintf("validation is PARTIAL — the accepted classes below are the checks that are missing (%d variants did not complete)", errored)
 	default:
 		return "validation is PARTIAL — the accepted classes below are the checks that are missing"
 	}

--- a/internal/probes/mcptransport/originvalidation.go
+++ b/internal/probes/mcptransport/originvalidation.go
@@ -373,8 +373,9 @@ func (p *OriginValidation) Probe(ctx context.Context, gen types.Generator) ([]*a
 	// attempt either way.
 	base := stampClass(p.attemptFromVariant(p.sendVariant(ctx, client, endpoint, transport, "", "", classBaseline)))
 	attempts = append(attempts, base)
-	if !metaBool(base, attempt.MetadataKeyOriginValidationAccepted) {
-		slog.Info("mcptransport.OriginValidation: baseline (no Origin) not accepted; downstream bypass results may be inconclusive", "endpoint", endpoint, "transport", transport)
+	baselineAccepted := metaBool(base, attempt.MetadataKeyOriginValidationAccepted)
+	if !baselineAccepted {
+		slog.Info("mcptransport.OriginValidation: baseline (no Origin) not accepted; refusals are not attributable to Origin validation", "endpoint", endpoint, "transport", transport)
 	}
 
 	// 2-4. The bypass sweep. Every variant below asks the SAME question — does
@@ -418,7 +419,7 @@ func (p *OriginValidation) Probe(ctx context.Context, gen types.Generator) ([]*a
 	preflight := stampClass(p.probePreflight(ctx, client, endpoint, "https://"+p.nonce[:8]+".example.org", u.Host))
 
 	// 6. One finding for the endpoint, carrying every variant as evidence.
-	if agg := p.aggregateSweep(endpoint, transport, variants, corsResultFrom(preflight)); agg != nil {
+	if agg := p.aggregateSweep(endpoint, transport, variants, corsResultFrom(preflight), baselineAccepted); agg != nil {
 		attempts = append(attempts, stampClass(agg))
 	}
 	attempts = append(attempts, preflight)
@@ -501,7 +502,7 @@ func corsResultFrom(preflight *attempt.Attempt) corsReflection {
 // "baseline", and the accepted flag is true when ANY variant was accepted.
 // The target-class severity tiering is untouched — the caller stamps it on
 // this attempt exactly as it does on every other.
-func (p *OriginValidation) aggregateSweep(endpoint, transport string, variants []variantResult, cors corsReflection) *attempt.Attempt {
+func (p *OriginValidation) aggregateSweep(endpoint, transport string, variants []variantResult, cors corsReflection, baselineAccepted bool) *attempt.Attempt {
 	if len(variants) == 0 {
 		return nil
 	}
@@ -561,7 +562,12 @@ func (p *OriginValidation) aggregateSweep(endpoint, transport string, variants [
 		a.Metadata[attempt.MetadataKeyOriginValidationCredentialedRead] = cors == corsPresent
 	}
 	untested := untestedClasses(variants)
-	a.AddOutput(renderSweepEvidence(endpoint, transport, accepted, rejected, errored, cors, untested))
+	if untested == nil {
+		untested = []string{}
+	}
+	a.Metadata[attempt.MetadataKeyOriginValidationBaselineAccepted] = baselineAccepted
+	a.Metadata[attempt.MetadataKeyOriginValidationUntestedClasses] = untested
+	a.AddOutput(renderSweepEvidence(endpoint, transport, accepted, rejected, errored, cors, baselineAccepted))
 
 	// Every variant failed at the transport — the endpoint was never actually
 	// tested. Reporting that as SAFE would hide a broken scan behind a green
@@ -649,7 +655,7 @@ func describeSweep(accepted, total int) string {
 // Which variants pass is the actionable half for a remediator: an accepted
 // case-variant alone means the allowlist exists but compares case-sensitively,
 // which is a different fix from an endpoint that accepts any origin at all.
-func renderSweepEvidence(endpoint, transport string, accepted, rejected, errored []variantResult, cors corsReflection, untested []string) string {
+func renderSweepEvidence(endpoint, transport string, accepted, rejected, errored []variantResult, cors corsReflection, baselineAccepted bool) string {
 	var b strings.Builder
 	total := len(accepted) + len(rejected) + len(errored)
 
@@ -657,10 +663,18 @@ func renderSweepEvidence(endpoint, transport string, accepted, rejected, errored
 	fmt.Fprintf(&b, "%d of %d crafted Origin/Host values were accepted. A spec-compliant\n", len(accepted), total)
 	fmt.Fprintf(&b, "allowlist validator would have refused all %d.\n\n", total)
 
-	fmt.Fprintf(&b, "Validator verdict: %s\n\n", validatorVerdict(len(accepted), len(rejected), len(errored), untested))
+	// State the baseline as a fact. The caveat is added only where it is both
+	// true and load-bearing: the endpoint refused us AND there are refusals a
+	// reader might otherwise credit to Origin validation.
+	fmt.Fprintf(&b, "Baseline (no Origin header): %s\n", baselineServedWord(baselineAccepted))
+	if !baselineAccepted && len(rejected) > 0 {
+		b.WriteString("The endpoint refused an unauthenticated request carrying no Origin at all, so\n" +
+			"the refusals below are not attributable to Origin validation.\n")
+	}
+	b.WriteString("\n")
 
 	writeBucket(&b, "ACCEPTED — served a request it should have refused", accepted)
-	writeBucket(&b, "REJECTED — refused as a hardened server should", rejected)
+	writeBucket(&b, "REFUSED by the endpoint", rejected)
 	writeBucket(&b, "NOT TESTED — request failed in transit", errored)
 
 	switch cors {
@@ -686,32 +700,13 @@ func renderSweepEvidence(endpoint, transport string, accepted, rejected, errored
 	return b.String()
 }
 
-// validatorVerdict states what the accept/reject split means about the
-// server's validator, which is the thing a remediator acts on.
-//
-// A class with no completed variant is a check that never ran, so a verdict
-// drawn over one says so: "we refused every check we managed to run" is a
-// materially weaker claim than "we refused everything", and the verdict line
-// is the sentence a reader takes away. Losing some variants of an
-// otherwise-exercised class is ordinary sampling and only warrants a
-// parenthetical.
-func validatorVerdict(accepted, rejected, errored int, untested []string) string {
-	switch {
-	case accepted == 0 && rejected == 0:
-		return fmt.Sprintf("nothing was tested — all %d variants failed in transit", errored)
-	case accepted == 0 && len(untested) > 0:
-		return fmt.Sprintf("every check that ran was refused, but no %s variant completed — that check never ran, so validation cannot be called enforced", strings.Join(untested, " / "))
-	case accepted == 0 && errored > 0:
-		return fmt.Sprintf("every crafted value that landed was refused — Origin/Host validation is enforced (%d variants did not complete, but every check class was still exercised)", errored)
-	case accepted == 0:
-		return "every crafted value was refused — Origin/Host validation is enforced"
-	case rejected == 0 && errored == 0:
-		return "NO Origin/Host validation is enforced — every crafted value was accepted"
-	case errored > 0:
-		return fmt.Sprintf("validation is PARTIAL — the accepted classes below are the checks that are missing (%d variants did not complete)", errored)
-	default:
-		return "validation is PARTIAL — the accepted classes below are the checks that are missing"
+// baselineServedWord renders the baseline fact for the evidence header. The
+// probe states the fact; classifying what it means is the detector's job.
+func baselineServedWord(accepted bool) string {
+	if accepted {
+		return "SERVED"
 	}
+	return "REFUSED"
 }
 
 // writeBucket renders one accept/reject/error group, skipping empty ones.

--- a/internal/probes/mcptransport/originvalidation.go
+++ b/internal/probes/mcptransport/originvalidation.go
@@ -590,10 +590,23 @@ func (p *OriginValidation) aggregateSweep(endpoint, transport string, variants [
 	// then proven on the wire, and downgrading a confirmed finding because an
 	// unrelated variant timed out would lose a real vulnerability.
 	if len(accepted) == 0 && len(untested) > 0 {
-		a.Metadata[attempt.MetadataKeyInconclusive] = true
-		a.Metadata[attempt.MetadataKeyInconclusiveReason] = fmt.Sprintf(
+		reason := fmt.Sprintf(
 			"no %s variant completed, so that check never ran; every class that did run was refused",
 			strings.Join(untested, ", "))
+		a.Metadata[attempt.MetadataKeyInconclusive] = true
+		a.Metadata[attempt.MetadataKeyInconclusiveReason] = reason
+
+		// The inconclusive flag alone is not enough to be seen. It maps to
+		// InconclusiveScore (0.5), and both results.Verdict and
+		// Attempt.IsVulnerable treat only scores STRICTLY above 0.5 as
+		// non-safe — so the row still renders SAFE, which is the very thing
+		// the flag exists to prevent. Erroring the attempt is the only way to
+		// render non-passing without inventing a finding: a score above the
+		// threshold would make Guard emit a risk we have no evidence for.
+		//
+		// Each variant was already retried once, so reaching here means a
+		// whole check failed twice over — worth surfacing loudly.
+		a.SetError(fmt.Errorf("mcptransport.OriginValidation: %s", reason))
 	}
 	return a
 }
@@ -747,7 +760,26 @@ func (p *OriginValidation) resolveEndpoint(gen types.Generator) string {
 // Returns a plain result rather than an attempt so the caller decides what
 // becomes a finding: the baseline gets its own attempt, while the bypass
 // variants are folded into one (see aggregateSweep).
+// A transport failure is retried once before the variant is recorded as
+// untested. That matters because an untested CLASS now errors the whole sweep
+// (see aggregateSweep), and in Guard a scan that produces no findings but does
+// produce probe errors fails the job outright. One dropped connection should
+// not do that; two consecutive failures to the same endpoint is a real signal.
+//
+// Not retried when the context is already done — the scan is being torn down
+// and a second attempt would only add latency.
 func (p *OriginValidation) sendVariant(ctx context.Context, client *http.Client, endpoint, transport, origin, host string, class originValidationClass) variantResult {
+	v := p.sendVariantOnce(ctx, client, endpoint, transport, origin, host, class)
+	if v.err == nil || ctx.Err() != nil {
+		return v
+	}
+	slog.Debug("mcptransport.OriginValidation: variant failed in transit, retrying once",
+		"class", string(class), "origin", origin, "host", host, "err", v.err)
+	return p.sendVariantOnce(ctx, client, endpoint, transport, origin, host, class)
+}
+
+// sendVariantOnce performs a single attempt; see sendVariant for the retry.
+func (p *OriginValidation) sendVariantOnce(ctx context.Context, client *http.Client, endpoint, transport, origin, host string, class originValidationClass) variantResult {
 	v := variantResult{class: class, origin: origin, host: host}
 
 	var (

--- a/internal/probes/mcptransport/originvalidation.go
+++ b/internal/probes/mcptransport/originvalidation.go
@@ -580,40 +580,6 @@ func (p *OriginValidation) aggregateSweep(endpoint, transport string, variants [
 	a.Complete()
 	a.Metadata[attempt.MetadataKeyOriginValidationAccepted] = len(accepted) > 0
 
-	// A whole bypass class went untested — every variant of it died in
-	// transit — and nothing else was accepted. That is a check this sweep
-	// never ran, not merely a lost sample, so "the endpoint refused
-	// everything" is a conclusion it did not earn. Mark it inconclusive,
-	// matching how the sibling SSESessionHijack probe flags a determination
-	// it could not make.
-	//
-	// Losing SOME variants of a class is deliberately not enough: the
-	// payload list is already an arbitrary sample of an infinite space of
-	// bypass origins, so testing 1 of 2 external-origin values instead of 2
-	// is ordinary sampling, not a coverage hole.
-	//
-	// Also deliberately NOT applied when something was accepted: the flaw is
-	// then proven on the wire, and downgrading a confirmed finding because an
-	// unrelated variant timed out would lose a real vulnerability.
-	if len(accepted) == 0 && len(untested) > 0 {
-		reason := fmt.Sprintf(
-			"no %s variant completed, so that check never ran; every class that did run was refused",
-			strings.Join(untested, ", "))
-		a.Metadata[attempt.MetadataKeyInconclusive] = true
-		a.Metadata[attempt.MetadataKeyInconclusiveReason] = reason
-
-		// The inconclusive flag alone is not enough to be seen. It maps to
-		// InconclusiveScore (0.5), and both results.Verdict and
-		// Attempt.IsVulnerable treat only scores STRICTLY above 0.5 as
-		// non-safe — so the row still renders SAFE, which is the very thing
-		// the flag exists to prevent. Erroring the attempt is the only way to
-		// render non-passing without inventing a finding: a score above the
-		// threshold would make Guard emit a risk we have no evidence for.
-		//
-		// Each variant was already retried once, so reaching here means a
-		// whole check failed twice over — worth surfacing loudly.
-		a.SetError(fmt.Errorf("mcptransport.OriginValidation: %s", reason))
-	}
 	return a
 }
 

--- a/internal/probes/mcptransport/originvalidation.go
+++ b/internal/probes/mcptransport/originvalidation.go
@@ -507,10 +507,14 @@ func (p *OriginValidation) aggregateSweep(endpoint, transport string, variants [
 	}
 
 	var (
-		accepted       []variantResult
-		rejected       []variantResult
-		errored        []variantResult
-		acceptedClass  []string
+		accepted []variantResult
+		rejected []variantResult
+		errored  []variantResult
+		// Empty, not nil: a server that refuses everything accepts no class,
+		// and that is the COMMON case on a healthy target. A nil slice
+		// marshals to JSON null, so a consumer iterating accepted_classes
+		// would blow up on exactly the endpoints that are fine.
+		acceptedClass  = make([]string, 0, len(variants))
 		seenClass      = map[originValidationClass]bool{}
 		variantDetails = make([]map[string]any, 0, len(variants))
 	)

--- a/internal/probes/mcptransport/originvalidation.go
+++ b/internal/probes/mcptransport/originvalidation.go
@@ -722,10 +722,15 @@ func (p *OriginValidation) resolveEndpoint(gen types.Generator) string {
 // becomes a finding: the baseline gets its own attempt, while the bypass
 // variants are folded into one (see aggregateSweep).
 // A transport failure is retried once before the variant is recorded as
-// untested. That matters because an untested CLASS now errors the whole sweep
-// (see aggregateSweep), and in Guard a scan that produces no findings but does
-// produce probe errors fails the job outright. One dropped connection should
-// not do that; two consecutive failures to the same endpoint is a real signal.
+// untested. That matters because a wholly untested class costs the sweep its
+// conclusion: the detector scores it inconclusive rather than safe, since a
+// value we could not send might have been the one the endpoint accepts. One
+// dropped connection should not cost a clean endpoint its verdict; two
+// consecutive failures to the same endpoint is a real signal.
+//
+// Note that only classes with a single payload (null-origin, and case-variant
+// where it applies) are one failure away from being untested at all — the
+// others have a sibling that covers the class.
 //
 // Not retried when the context is already done — the scan is being torn down
 // and a second attempt would only add latency.

--- a/internal/probes/mcptransport/originvalidation_test.go
+++ b/internal/probes/mcptransport/originvalidation_test.go
@@ -671,19 +671,10 @@ func TestOriginValidation_UntestedClassIsInconclusive(t *testing.T) {
 		t.Fatal("expected an aggregated sweep attempt")
 	}
 
-	errored := variantOutcomes(t, attempts)[variantNotTested]
-	if errored == 0 {
+	if variantOutcomes(t, attempts)[variantNotTested] == 0 {
 		t.Fatal("expected some variants to fail in transit; test server did not misbehave as intended")
 	}
 
-	if !metaBool(sweep, attempt.MetadataKeyInconclusive) {
-		t.Errorf("a sweep with nothing accepted and a wholly untested class (%d failed variants) must be inconclusive, not safe", errored)
-	}
-	reason, _ := sweep.GetMetadata(attempt.MetadataKeyInconclusiveReason)
-	reasonStr, _ := reason.(string)
-	if !strings.Contains(reasonStr, string(classUnexpectedHost)) {
-		t.Errorf("reason should name the class that never ran; got %q", reasonStr)
-	}
 	// The untested class is recorded as a fact for the detector and the report.
 	rawUntested, ok := sweep.GetMetadata(attempt.MetadataKeyOriginValidationUntestedClasses)
 	if !ok {
@@ -709,14 +700,16 @@ func TestOriginValidation_UntestedClassIsInconclusive(t *testing.T) {
 		t.Errorf("probe evidence must not claim enforcement; got:\n%s", sweepOutput(t, sweep))
 	}
 
-	// The inconclusive flag alone renders as SAFE (0.5 is not > 0.5), so the
-	// attempt must also be errored to be visibly non-passing. Without this the
-	// metadata says "could not assess" while the row says "safe".
-	if sweep.Status != attempt.StatusError {
-		t.Errorf("sweep status = %q, want %q — an unassessable check must not render as a pass", sweep.Status, attempt.StatusError)
+	// The probe records the fact and stops. Deciding what an untested class
+	// MEANS is the detector's job, so the probe must not classify it here:
+	// no inconclusive flag, and no error status — the attempt did not fail,
+	// %d of its requests got clean HTTP answers.
+	if metaBool(sweep, attempt.MetadataKeyInconclusive) {
+		t.Errorf("the probe must not set the inconclusive flag; that classification belongs to the detector")
 	}
-	if !strings.Contains(sweep.Error, string(classUnexpectedHost)) {
-		t.Errorf("sweep error should name the untested class; got %q", sweep.Error)
+	if sweep.Status == attempt.StatusError {
+		t.Errorf("the sweep did not fail — %d requests were answered — so it must not carry an error status: %q",
+			variantOutcomes(t, attempts)[variantRefused], sweep.Error)
 	}
 }
 

--- a/internal/probes/mcptransport/originvalidation_test.go
+++ b/internal/probes/mcptransport/originvalidation_test.go
@@ -179,6 +179,49 @@ func acceptedVariantClasses(t *testing.T, attempts []*attempt.Attempt) map[strin
 	return got
 }
 
+// killConn hijacks and closes the connection so the client sees a transport
+// failure rather than any HTTP response — how the tests simulate a variant
+// that never reaches the validator.
+func killConn(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		t.Errorf("test server cannot hijack; cannot simulate a transport failure")
+		return
+	}
+	conn, _, err := hj.Hijack()
+	if err != nil {
+		t.Errorf("hijack: %v", err)
+		return
+	}
+	_ = conn.Close()
+}
+
+// sweepOutput returns the aggregated attempt's single evidence output, failing
+// with a clear message rather than panicking if the attempt carries none.
+func sweepOutput(t *testing.T, a *attempt.Attempt) string {
+	t.Helper()
+	if len(a.Outputs) == 0 {
+		t.Fatal("sweep attempt carries no evidence output")
+	}
+	return a.Outputs[0]
+}
+
+// variantOutcomes counts the recorded per-variant outcomes by their explicit
+// tri-state, rather than inferring failure from the rendered result text.
+func variantOutcomes(t *testing.T, attempts []*attempt.Attempt) map[string]int {
+	t.Helper()
+	counts := map[string]int{}
+	for _, v := range sweepVariants(t, attempts) {
+		o, ok := v["outcome"].(string)
+		if !ok {
+			t.Fatalf("variant %v has no string outcome — the evidence contract changed", v)
+		}
+		counts[o]++
+	}
+	return counts
+}
+
 // sweepVariants returns the per-variant detail recorded on the aggregated
 // sweep attempt.
 func sweepVariants(t *testing.T, attempts []*attempt.Attempt) []map[string]any {
@@ -304,8 +347,8 @@ func TestOriginValidation_SweepEvidenceRecordsEveryVariant(t *testing.T) {
 	if len(sweep.Outputs) != 1 {
 		t.Errorf("aggregated attempt should carry exactly one evidence output, got %d", len(sweep.Outputs))
 	}
-	if !strings.Contains(sweep.Outputs[0], "NO Origin/Host validation is enforced") {
-		t.Errorf("evidence should state the validator verdict for an any-origin server; got:\n%s", sweep.Outputs[0])
+	if !strings.Contains(sweepOutput(t, sweep), "NO Origin/Host validation is enforced") {
+		t.Errorf("evidence should state the validator verdict for an any-origin server; got:\n%s", sweepOutput(t, sweep))
 	}
 }
 
@@ -345,13 +388,13 @@ func TestOriginValidation_PartialValidationStillOneFinding(t *testing.T) {
 	if gotN == 0 || gotN >= sentN {
 		t.Errorf("expected a partial accept (0 < accepted < sent), got accepted=%d sent=%d", gotN, sentN)
 	}
-	if !strings.Contains(sweep.Outputs[0], "validation is PARTIAL") {
-		t.Errorf("evidence should call out partial validation; got:\n%s", sweep.Outputs[0])
+	if !strings.Contains(sweepOutput(t, sweep), "validation is PARTIAL") {
+		t.Errorf("evidence should call out partial validation; got:\n%s", sweepOutput(t, sweep))
 	}
 	// The rejected variants must be visible too — that is what tells a
 	// remediator the allowlist exists and is merely incomplete.
-	if !strings.Contains(sweep.Outputs[0], "REJECTED") {
-		t.Errorf("evidence should list the refused variants; got:\n%s", sweep.Outputs[0])
+	if !strings.Contains(sweepOutput(t, sweep), "REJECTED") {
+		t.Errorf("evidence should list the refused variants; got:\n%s", sweepOutput(t, sweep))
 	}
 
 	accepted := acceptedVariantClasses(t, attempts)
@@ -479,9 +522,9 @@ func TestOriginValidation_CORSReflectionWithCredsFired(t *testing.T) {
 	if !metaBool(sweep, attempt.MetadataKeyOriginValidationCredentialedRead) {
 		t.Errorf("sweep attempt should record the credentialed-read escalation")
 	}
-	if !strings.Contains(sweep.Outputs[0], "Credentialed CORS reflection: PRESENT") ||
-		!strings.Contains(sweep.Outputs[0], "READ") {
-		t.Errorf("aggregated evidence should escalate the impact when the preflight reflects credentials; got:\n%s", sweep.Outputs[0])
+	if !strings.Contains(sweepOutput(t, sweep), "Credentialed CORS reflection: PRESENT") ||
+		!strings.Contains(sweepOutput(t, sweep), "READ") {
+		t.Errorf("aggregated evidence should escalate the impact when the preflight reflects credentials; got:\n%s", sweepOutput(t, sweep))
 	}
 }
 
@@ -504,8 +547,8 @@ func TestOriginValidation_NoCORSReflectionStatesLesserImpact(t *testing.T) {
 	if metaBool(sweep, attempt.MetadataKeyOriginValidationCredentialedRead) {
 		t.Errorf("vulnServer sets no CORS headers; credentialed-read should be false")
 	}
-	if !strings.Contains(sweep.Outputs[0], "Credentialed CORS reflection: absent") {
-		t.Errorf("evidence should state the lesser impact without reflection; got:\n%s", sweep.Outputs[0])
+	if !strings.Contains(sweepOutput(t, sweep), "Credentialed CORS reflection: absent") {
+		t.Errorf("evidence should state the lesser impact without reflection; got:\n%s", sweepOutput(t, sweep))
 	}
 }
 
@@ -586,8 +629,8 @@ func TestOriginValidation_AllVariantsFailedIsErrorNotSafe(t *testing.T) {
 	}
 	// The evidence still names every variant that could not be tested, so the
 	// operator can see the sweep was not silently truncated.
-	if !strings.Contains(sweep.Outputs[0], "NOT TESTED") {
-		t.Errorf("evidence should list the untested variants; got:\n%s", sweep.Outputs[0])
+	if !strings.Contains(sweepOutput(t, sweep), "NOT TESTED") {
+		t.Errorf("evidence should list the untested variants; got:\n%s", sweepOutput(t, sweep))
 	}
 }
 
@@ -601,15 +644,7 @@ func TestOriginValidation_UntestedClassIsInconclusive(t *testing.T) {
 	// Host-header variants — so the whole unexpected-host class goes untested.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.Host, "example.") {
-			hj, ok := w.(http.Hijacker)
-			if !ok {
-				t.Errorf("test server cannot hijack; cannot simulate transport failure")
-				return
-			}
-			conn, _, err := hj.Hijack()
-			if err == nil {
-				_ = conn.Close()
-			}
+			killConn(t, w)
 			return
 		}
 		if r.Header.Get("Origin") != "" {
@@ -631,14 +666,7 @@ func TestOriginValidation_UntestedClassIsInconclusive(t *testing.T) {
 		t.Fatal("expected an aggregated sweep attempt")
 	}
 
-	variants := sweepVariants(t, attempts)
-	errored := 0
-	for _, v := range variants {
-		if s, _ := v["result"].(string); strings.Contains(s, "HTTP ") {
-			continue
-		}
-		errored++
-	}
+	errored := variantOutcomes(t, attempts)[variantNotTested]
 	if errored == 0 {
 		t.Fatal("expected some variants to fail in transit; test server did not misbehave as intended")
 	}
@@ -652,8 +680,8 @@ func TestOriginValidation_UntestedClassIsInconclusive(t *testing.T) {
 		t.Errorf("reason should name the class that never ran; got %q", reasonStr)
 	}
 	// The verdict a reader takes away must not claim enforcement outright.
-	if !strings.Contains(sweep.Outputs[0], "that check never ran, so validation cannot be called enforced") {
-		t.Errorf("verdict must not claim enforcement when a whole class went untested; got:\n%s", sweep.Outputs[0])
+	if !strings.Contains(sweepOutput(t, sweep), "that check never ran, so validation cannot be called enforced") {
+		t.Errorf("verdict must not claim enforcement when a whole class went untested; got:\n%s", sweepOutput(t, sweep))
 	}
 }
 
@@ -669,11 +697,7 @@ func TestOriginValidation_LostSampleIsNotInconclusive(t *testing.T) {
 	// exercised by its sibling, and every other class completes.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.Header.Get("Origin"), "cdn-") {
-			if hj, ok := w.(http.Hijacker); ok {
-				if conn, _, err := hj.Hijack(); err == nil {
-					_ = conn.Close()
-				}
-			}
+			killConn(t, w)
 			return
 		}
 		// Refuse both crafted Origins AND crafted Hosts, so nothing is
@@ -702,7 +726,7 @@ func TestOriginValidation_LostSampleIsNotInconclusive(t *testing.T) {
 	// external-origin one whose sibling still landed.
 	failed := 0
 	for _, v := range sweepVariants(t, attempts) {
-		if s, _ := v["result"].(string); !strings.Contains(s, "HTTP ") {
+		if o, _ := v["outcome"].(string); o == variantNotTested {
 			failed++
 			if c, _ := v["class"].(string); c != string(classExternalOrigin) {
 				t.Errorf("expected only an external-origin variant to fail, got class %q", c)
@@ -721,8 +745,8 @@ func TestOriginValidation_LostSampleIsNotInconclusive(t *testing.T) {
 	if metaBool(sweep, attempt.MetadataKeyInconclusive) {
 		t.Errorf("losing one sample of an exercised class must not mark the sweep inconclusive")
 	}
-	if !strings.Contains(sweep.Outputs[0], "every check class was still exercised") {
-		t.Errorf("verdict should note the lost sample without retracting the verdict; got:\n%s", sweep.Outputs[0])
+	if !strings.Contains(sweepOutput(t, sweep), "every check class was still exercised") {
+		t.Errorf("verdict should note the lost sample without retracting the verdict; got:\n%s", sweepOutput(t, sweep))
 	}
 }
 
@@ -759,11 +783,7 @@ func TestUntestedClasses(t *testing.T) {
 func TestOriginValidation_ConfirmedFindingNotDowngradedByFailures(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.Host, "example.") {
-			if hj, ok := w.(http.Hijacker); ok {
-				if conn, _, err := hj.Hijack(); err == nil {
-					_ = conn.Close()
-				}
-			}
+			killConn(t, w)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -796,11 +816,7 @@ func TestOriginValidation_UntestedPreflightIsNotAbsence(t *testing.T) {
 	// Serves POST/GET normally but drops the OPTIONS preflight connection.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodOptions {
-			if hj, ok := w.(http.Hijacker); ok {
-				if conn, _, err := hj.Hijack(); err == nil {
-					_ = conn.Close()
-				}
-			}
+			killConn(t, w)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -820,11 +836,11 @@ func TestOriginValidation_UntestedPreflightIsNotAbsence(t *testing.T) {
 	if _, ok := sweep.GetMetadata(attempt.MetadataKeyOriginValidationCredentialedRead); ok {
 		t.Errorf("credentialed-read metadata must be omitted when the preflight never completed")
 	}
-	if strings.Contains(sweep.Outputs[0], "Credentialed CORS reflection: absent") {
-		t.Errorf("an untested preflight must not be reported as absence; got:\n%s", sweep.Outputs[0])
+	if strings.Contains(sweepOutput(t, sweep), "Credentialed CORS reflection: absent") {
+		t.Errorf("an untested preflight must not be reported as absence; got:\n%s", sweepOutput(t, sweep))
 	}
-	if !strings.Contains(sweep.Outputs[0], "Credentialed CORS reflection: NOT TESTED") {
-		t.Errorf("evidence should say the preflight was not tested; got:\n%s", sweep.Outputs[0])
+	if !strings.Contains(sweepOutput(t, sweep), "Credentialed CORS reflection: NOT TESTED") {
+		t.Errorf("evidence should say the preflight was not tested; got:\n%s", sweepOutput(t, sweep))
 	}
 }
 

--- a/internal/probes/mcptransport/originvalidation_test.go
+++ b/internal/probes/mcptransport/originvalidation_test.go
@@ -714,10 +714,10 @@ func TestOriginValidation_UntestedClassIsInconclusive(t *testing.T) {
 }
 
 // TestOriginValidation_TransientFailureIsRetried: a single dropped connection
-// must not be reported as an untested check. It would error the whole sweep,
-// and in Guard a scan with no findings but with probe errors fails the job —
-// so one flake would fail an otherwise-clean scan. Two consecutive failures is
-// the real signal; one is not.
+// must not be reported as an untested check. A wholly untested class costs the
+// sweep its conclusion — the detector scores it inconclusive rather than safe —
+// so one flake would deny a clean endpoint its verdict. Two consecutive
+// failures is the real signal; one is not.
 func TestOriginValidation_TransientFailureIsRetried(t *testing.T) {
 	var mu sync.Mutex
 	seen := map[string]int{}

--- a/internal/probes/mcptransport/originvalidation_test.go
+++ b/internal/probes/mcptransport/originvalidation_test.go
@@ -2,6 +2,7 @@ package mcptransport
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -750,6 +751,40 @@ func TestOriginValidation_LostSampleIsNotInconclusive(t *testing.T) {
 	}
 }
 
+// TestOriginValidation_AcceptedClassesMarshalsAsArray: a server that refuses
+// everything accepts no class, which is the COMMON case on a healthy target.
+// A nil slice marshals to JSON null, so a consumer iterating accepted_classes
+// would break on exactly the endpoints that are fine. Must be [] not null.
+func TestOriginValidation_AcceptedClassesMarshalsAsArray(t *testing.T) {
+	p := newOriginValidationProbe(t, registry.Config{})
+	agg := p.aggregateSweep("http://example.invalid", "http", []variantResult{
+		{class: classExternalOrigin, result: "HTTP 403, text/plain"},
+	}, corsAbsent)
+	if agg == nil {
+		t.Fatal("expected an aggregated attempt")
+	}
+
+	raw, ok := agg.GetMetadata(attempt.MetadataKeyOriginValidationAcceptedClasses)
+	if !ok {
+		t.Fatal("missing accepted-classes metadata")
+	}
+	classes, ok := raw.([]string)
+	if !ok {
+		t.Fatalf("accepted-classes is %T, want []string", raw)
+	}
+	if classes == nil {
+		t.Error("accepted-classes is a nil slice; it must be empty-but-non-nil so it marshals as []")
+	}
+
+	blob, err := json.Marshal(map[string]any{"accepted_classes": classes})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(blob), `"accepted_classes":[]`) {
+		t.Errorf("accepted_classes must serialise as [], got %s", blob)
+	}
+}
+
 // TestUntestedClasses covers the class-coverage helper directly: a class is
 // "untested" only when NOT ONE of its variants got a response.
 func TestUntestedClasses(t *testing.T) {
@@ -938,20 +973,41 @@ func TestOriginValidation_UsesBorrowedHTTPClient(t *testing.T) {
 	if seenCount == 0 {
 		t.Fatalf("recording transport saw NO requests — probe built its own client and bypassed the generator")
 	}
-	// Strict one-to-one against the requests the probe actually made. Since
-	// LAB-5584 that is no longer len(attempts) — the sweep's variants share a
-	// single attempt — so count them from the sweep's own record: baseline +
-	// every variant + the preflight. Anything less proves the probe made a
-	// side-channel request bypassing the borrowed client. Fixes CodeRabbit #8.
-	sweep := findAttemptByClass(attempts, classSweep)
-	if sweep == nil {
-		t.Fatal("expected an aggregated sweep attempt")
-	}
-	raw, _ := sweep.GetMetadata(attempt.MetadataKeyOriginValidationVariantsSent)
-	variantsSent, _ := raw.(int)
-	wantRequests := 1 + variantsSent + 1 // baseline + sweep variants + preflight
+	// Strict one-to-one against an expectation derived from the payload
+	// builders, NOT from the sweep's own variants_sent counter. Deriving it
+	// from metadata the aggregation writes would be circular: a probe that
+	// both skipped a request and under-counted it would still pass.
+	//
+	// httptest binds an all-numeric host, so swapCase is a no-op and the
+	// case-variant is (correctly) not sent — hence no term for it here.
+	wantRequests := 1 + // baseline
+		len(p.buildOriginPayloads()) +
+		len(p.buildHostPayloads()) +
+		1 // CORS preflight
 	if seenCount != wantRequests {
-		t.Errorf("requests=%d, seen=%d — not every request used the borrowed client (side-channel HTTP)", wantRequests, seenCount)
+		t.Errorf("want %d requests, transport saw %d — a request bypassed the borrowed client, or one was never sent", wantRequests, seenCount)
+	}
+
+	// Cross-check the evidence against the wire: every Origin the aggregated
+	// finding claims it sent must actually appear on a recorded request. This
+	// catches the aggregation inventing or dropping variants independently of
+	// the count above.
+	rec.mu.Lock()
+	onWire := map[string]bool{}
+	for _, r := range rec.reqs {
+		if o := r.Header.Get("Origin"); o != "" {
+			onWire[o] = true
+		}
+	}
+	rec.mu.Unlock()
+	for _, v := range sweepVariants(t, attempts) {
+		o, ok := v["origin"].(string)
+		if !ok {
+			continue // Host-only variant; no Origin header to match
+		}
+		if !onWire[o] {
+			t.Errorf("evidence reports Origin %q but no request carrying it reached the transport", o)
+		}
 	}
 }
 

--- a/internal/probes/mcptransport/originvalidation_test.go
+++ b/internal/probes/mcptransport/originvalidation_test.go
@@ -348,8 +348,13 @@ func TestOriginValidation_SweepEvidenceRecordsEveryVariant(t *testing.T) {
 	if len(sweep.Outputs) != 1 {
 		t.Errorf("aggregated attempt should carry exactly one evidence output, got %d", len(sweep.Outputs))
 	}
-	if !strings.Contains(sweepOutput(t, sweep), "NO Origin/Host validation is enforced") {
-		t.Errorf("evidence should state the validator verdict for an any-origin server; got:\n%s", sweepOutput(t, sweep))
+	if !strings.Contains(sweepOutput(t, sweep), "Baseline (no Origin header): SERVED") {
+		t.Errorf("evidence should state the baseline fact; got:\n%s", sweepOutput(t, sweep))
+	}
+	// Nothing was refused on this all-accepting server, so the evidence must
+	// not talk about refusals at all.
+	if strings.Contains(sweepOutput(t, sweep), "refusals below") {
+		t.Errorf("evidence should not reference refusals when there are none; got:\n%s", sweepOutput(t, sweep))
 	}
 }
 
@@ -389,13 +394,12 @@ func TestOriginValidation_PartialValidationStillOneFinding(t *testing.T) {
 	if gotN == 0 || gotN >= sentN {
 		t.Errorf("expected a partial accept (0 < accepted < sent), got accepted=%d sent=%d", gotN, sentN)
 	}
-	if !strings.Contains(sweepOutput(t, sweep), "validation is PARTIAL") {
-		t.Errorf("evidence should call out partial validation; got:\n%s", sweepOutput(t, sweep))
-	}
-	// The rejected variants must be visible too — that is what tells a
-	// remediator the allowlist exists and is merely incomplete.
-	if !strings.Contains(sweepOutput(t, sweep), "REJECTED") {
-		t.Errorf("evidence should list the refused variants; got:\n%s", sweepOutput(t, sweep))
+	// Both outcomes must be recorded as facts: what got through is the
+	// finding, what was refused is what tells a remediator the allowlist
+	// exists and is merely incomplete.
+	outcomes := variantOutcomes(t, attempts)
+	if outcomes[variantAccepted] == 0 || outcomes[variantRefused] == 0 {
+		t.Errorf("partial validation must record both accepted and refused variants; got %v", outcomes)
 	}
 
 	accepted := acceptedVariantClasses(t, attempts)
@@ -680,9 +684,29 @@ func TestOriginValidation_UntestedClassIsInconclusive(t *testing.T) {
 	if !strings.Contains(reasonStr, string(classUnexpectedHost)) {
 		t.Errorf("reason should name the class that never ran; got %q", reasonStr)
 	}
-	// The verdict a reader takes away must not claim enforcement outright.
-	if !strings.Contains(sweepOutput(t, sweep), "that check never ran, so validation cannot be called enforced") {
-		t.Errorf("verdict must not claim enforcement when a whole class went untested; got:\n%s", sweepOutput(t, sweep))
+	// The untested class is recorded as a fact for the detector and the report.
+	rawUntested, ok := sweep.GetMetadata(attempt.MetadataKeyOriginValidationUntestedClasses)
+	if !ok {
+		t.Fatal("sweep is missing the untested-classes metadata")
+	}
+	untested, ok := rawUntested.([]string)
+	if !ok {
+		t.Fatalf("untested-classes is %T, want []string", rawUntested)
+	}
+	found := false
+	for _, c := range untested {
+		if c == string(classUnexpectedHost) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("untested-classes should name the class that never ran; got %v", untested)
+	}
+	// The probe must never assert enforcement in its evidence — that is a
+	// classification, and it belongs to the detector. Guard against anyone
+	// reintroducing a verdict sentence here.
+	if strings.Contains(sweepOutput(t, sweep), "is enforced") {
+		t.Errorf("probe evidence must not claim enforcement; got:\n%s", sweepOutput(t, sweep))
 	}
 
 	// The inconclusive flag alone renders as SAFE (0.5 is not > 0.5), so the
@@ -820,8 +844,11 @@ func TestOriginValidation_LostSampleIsNotInconclusive(t *testing.T) {
 	if metaBool(sweep, attempt.MetadataKeyInconclusive) {
 		t.Errorf("losing one sample of an exercised class must not mark the sweep inconclusive")
 	}
-	if !strings.Contains(sweepOutput(t, sweep), "every check class was still exercised") {
-		t.Errorf("verdict should note the lost sample without retracting the verdict; got:\n%s", sweepOutput(t, sweep))
+	// The lost sample must NOT be recorded as an untested class — its sibling
+	// covered the class, so coverage is intact.
+	rawUntested, _ := sweep.GetMetadata(attempt.MetadataKeyOriginValidationUntestedClasses)
+	if untested, _ := rawUntested.([]string); len(untested) != 0 {
+		t.Errorf("a lost sample from an exercised class must not appear as untested; got %v", untested)
 	}
 }
 
@@ -833,7 +860,7 @@ func TestOriginValidation_AcceptedClassesMarshalsAsArray(t *testing.T) {
 	p := newOriginValidationProbe(t, registry.Config{})
 	agg := p.aggregateSweep("http://example.invalid", "http", []variantResult{
 		{class: classExternalOrigin, result: "HTTP 403, text/plain"},
-	}, corsAbsent)
+	}, corsAbsent, true)
 	if agg == nil {
 		t.Fatal("expected an aggregated attempt")
 	}

--- a/internal/probes/mcptransport/originvalidation_test.go
+++ b/internal/probes/mcptransport/originvalidation_test.go
@@ -168,7 +168,10 @@ func acceptedVariantClasses(t *testing.T, attempts []*attempt.Attempt) map[strin
 	if !ok {
 		t.Fatal("sweep attempt is missing the accepted-classes metadata")
 	}
-	classes, _ := raw.([]string)
+	classes, ok := raw.([]string)
+	if !ok {
+		t.Fatalf("accepted-classes metadata is %T, want []string — the evidence contract changed", raw)
+	}
 	got := map[string]bool{}
 	for _, c := range classes {
 		got[c] = true
@@ -188,7 +191,10 @@ func sweepVariants(t *testing.T, attempts []*attempt.Attempt) []map[string]any {
 	if !ok {
 		t.Fatal("sweep attempt is missing the variants metadata")
 	}
-	vs, _ := raw.([]map[string]any)
+	vs, ok := raw.([]map[string]any)
+	if !ok {
+		t.Fatalf("variants metadata is %T, want []map[string]any — the evidence contract changed", raw)
+	}
 	return vs
 }
 
@@ -582,6 +588,271 @@ func TestOriginValidation_AllVariantsFailedIsErrorNotSafe(t *testing.T) {
 	// operator can see the sweep was not silently truncated.
 	if !strings.Contains(sweep.Outputs[0], "NOT TESTED") {
 		t.Errorf("evidence should list the untested variants; got:\n%s", sweep.Outputs[0])
+	}
+}
+
+// TestOriginValidation_UntestedClassIsInconclusive: when EVERY variant of a
+// bypass class dies in transit, that check never ran. With nothing accepted,
+// "the endpoint refused everything" is not a conclusion the sweep earned — the
+// untested class might well have got through. Must not score a clean SAFE.
+// Regression guard for Codex/Claude review on PR #288.
+func TestOriginValidation_UntestedClassIsInconclusive(t *testing.T) {
+	// Refuses every Origin it sees, but kills the connection outright for the
+	// Host-header variants — so the whole unexpected-host class goes untested.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Host, "example.") {
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Errorf("test server cannot hijack; cannot simulate transport failure")
+				return
+			}
+			conn, _, err := hj.Hijack()
+			if err == nil {
+				_ = conn.Close()
+			}
+			return
+		}
+		if r.Header.Get("Origin") != "" {
+			http.Error(w, "origin not allowed", http.StatusForbidden)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(initializeOK))
+	}))
+	defer srv.Close()
+
+	p := newOriginValidationProbe(t, registry.Config{"endpoint": srv.URL})
+	attempts, err := p.Probe(context.Background(), endpointGen{url: srv.URL, transport: "http"})
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	sweep := findAttemptByClass(attempts, classSweep)
+	if sweep == nil {
+		t.Fatal("expected an aggregated sweep attempt")
+	}
+
+	variants := sweepVariants(t, attempts)
+	errored := 0
+	for _, v := range variants {
+		if s, _ := v["result"].(string); strings.Contains(s, "HTTP ") {
+			continue
+		}
+		errored++
+	}
+	if errored == 0 {
+		t.Fatal("expected some variants to fail in transit; test server did not misbehave as intended")
+	}
+
+	if !metaBool(sweep, attempt.MetadataKeyInconclusive) {
+		t.Errorf("a sweep with nothing accepted and a wholly untested class (%d failed variants) must be inconclusive, not safe", errored)
+	}
+	reason, _ := sweep.GetMetadata(attempt.MetadataKeyInconclusiveReason)
+	reasonStr, _ := reason.(string)
+	if !strings.Contains(reasonStr, string(classUnexpectedHost)) {
+		t.Errorf("reason should name the class that never ran; got %q", reasonStr)
+	}
+	// The verdict a reader takes away must not claim enforcement outright.
+	if !strings.Contains(sweep.Outputs[0], "that check never ran, so validation cannot be called enforced") {
+		t.Errorf("verdict must not claim enforcement when a whole class went untested; got:\n%s", sweep.Outputs[0])
+	}
+}
+
+// TestOriginValidation_LostSampleIsNotInconclusive: losing SOME variants of a
+// class that was otherwise exercised is ordinary sampling, not a coverage
+// hole — the payload list is already an arbitrary sample of an infinite space
+// of bypass origins. Marking that inconclusive would fire on every flaky
+// connection and drain the signal from the flag. This is the discriminating
+// case against the broader "any errored variant" rule.
+func TestOriginValidation_LostSampleIsNotInconclusive(t *testing.T) {
+	// Refuses every Origin, and kills the connection for exactly ONE of the
+	// two external-origin payloads (the "cdn-" one). external-origin is still
+	// exercised by its sibling, and every other class completes.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Origin"), "cdn-") {
+			if hj, ok := w.(http.Hijacker); ok {
+				if conn, _, err := hj.Hijack(); err == nil {
+					_ = conn.Close()
+				}
+			}
+			return
+		}
+		// Refuse both crafted Origins AND crafted Hosts, so nothing is
+		// accepted — otherwise the accepted>0 guard would short-circuit the
+		// inconclusive check and the test would prove nothing.
+		if r.Header.Get("Origin") != "" || strings.Contains(r.Host, "example.") {
+			http.Error(w, "not allowed", http.StatusForbidden)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(initializeOK))
+	}))
+	defer srv.Close()
+
+	p := newOriginValidationProbe(t, registry.Config{"endpoint": srv.URL})
+	attempts, err := p.Probe(context.Background(), endpointGen{url: srv.URL, transport: "http"})
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	sweep := findAttemptByClass(attempts, classSweep)
+	if sweep == nil {
+		t.Fatal("expected an aggregated sweep attempt")
+	}
+
+	// Non-vacuity: exactly one variant must have failed, and it must be an
+	// external-origin one whose sibling still landed.
+	failed := 0
+	for _, v := range sweepVariants(t, attempts) {
+		if s, _ := v["result"].(string); !strings.Contains(s, "HTTP ") {
+			failed++
+			if c, _ := v["class"].(string); c != string(classExternalOrigin) {
+				t.Errorf("expected only an external-origin variant to fail, got class %q", c)
+			}
+		}
+	}
+	if failed != 1 {
+		t.Fatalf("expected exactly 1 failed variant, got %d — test server did not misbehave as intended", failed)
+	}
+	// Non-vacuity: nothing accepted, so the inconclusive check below is
+	// actually reached rather than short-circuited by the accepted>0 guard.
+	if metaBool(sweep, attempt.MetadataKeyOriginValidationAccepted) {
+		t.Fatal("test server accepted a variant; the inconclusive path would be short-circuited")
+	}
+
+	if metaBool(sweep, attempt.MetadataKeyInconclusive) {
+		t.Errorf("losing one sample of an exercised class must not mark the sweep inconclusive")
+	}
+	if !strings.Contains(sweep.Outputs[0], "every check class was still exercised") {
+		t.Errorf("verdict should note the lost sample without retracting the verdict; got:\n%s", sweep.Outputs[0])
+	}
+}
+
+// TestUntestedClasses covers the class-coverage helper directly: a class is
+// "untested" only when NOT ONE of its variants got a response.
+func TestUntestedClasses(t *testing.T) {
+	boom := context.DeadlineExceeded
+	got := untestedClasses([]variantResult{
+		{class: classExternalOrigin, err: boom},
+		{class: classExternalOrigin}, // sibling landed → class IS exercised
+		{class: classNullOrigin, err: boom},
+		{class: classUnexpectedHost, err: boom},
+		{class: classUnexpectedHost, err: boom},
+		{class: classLocalhostLookalike},
+	})
+	want := []string{string(classNullOrigin), string(classUnexpectedHost)}
+	if len(got) != len(want) {
+		t.Fatalf("untestedClasses = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("untestedClasses[%d] = %q, want %q (order should follow sweep order)", i, got[i], want[i])
+		}
+	}
+	if len(untestedClasses(nil)) != 0 {
+		t.Errorf("no variants → no untested classes")
+	}
+}
+
+// TestOriginValidation_ConfirmedFindingNotDowngradedByFailures: the inconclusive
+// marking above must NOT fire when a variant was accepted — the flaw is proven
+// on the wire, and downgrading it because an unrelated variant timed out would
+// lose a real vulnerability.
+func TestOriginValidation_ConfirmedFindingNotDowngradedByFailures(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Host, "example.") {
+			if hj, ok := w.(http.Hijacker); ok {
+				if conn, _, err := hj.Hijack(); err == nil {
+					_ = conn.Close()
+				}
+			}
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(initializeOK))
+	}))
+	defer srv.Close()
+
+	p := newOriginValidationProbe(t, registry.Config{"endpoint": srv.URL})
+	attempts, err := p.Probe(context.Background(), endpointGen{url: srv.URL, transport: "http"})
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	sweep := findAttemptByClass(attempts, classSweep)
+	if sweep == nil {
+		t.Fatal("expected an aggregated sweep attempt")
+	}
+	if !metaBool(sweep, attempt.MetadataKeyOriginValidationAccepted) {
+		t.Fatal("expected the Origin variants to be accepted by this server")
+	}
+	if metaBool(sweep, attempt.MetadataKeyInconclusive) {
+		t.Errorf("a confirmed bypass must not be downgraded to inconclusive by unrelated transport failures")
+	}
+}
+
+// TestOriginValidation_UntestedPreflightIsNotAbsence: an errored CORS preflight
+// must report as NOT TESTED, never as "reflection absent" — asserting an
+// absence the probe never observed understates the finding's impact.
+// Regression guard for Codex review on PR #288.
+func TestOriginValidation_UntestedPreflightIsNotAbsence(t *testing.T) {
+	// Serves POST/GET normally but drops the OPTIONS preflight connection.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			if hj, ok := w.(http.Hijacker); ok {
+				if conn, _, err := hj.Hijack(); err == nil {
+					_ = conn.Close()
+				}
+			}
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(initializeOK))
+	}))
+	defer srv.Close()
+
+	p := newOriginValidationProbe(t, registry.Config{"endpoint": srv.URL})
+	attempts, err := p.Probe(context.Background(), endpointGen{url: srv.URL, transport: "http"})
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	sweep := findAttemptByClass(attempts, classSweep)
+	if sweep == nil {
+		t.Fatal("expected an aggregated sweep attempt")
+	}
+	if _, ok := sweep.GetMetadata(attempt.MetadataKeyOriginValidationCredentialedRead); ok {
+		t.Errorf("credentialed-read metadata must be omitted when the preflight never completed")
+	}
+	if strings.Contains(sweep.Outputs[0], "Credentialed CORS reflection: absent") {
+		t.Errorf("an untested preflight must not be reported as absence; got:\n%s", sweep.Outputs[0])
+	}
+	if !strings.Contains(sweep.Outputs[0], "Credentialed CORS reflection: NOT TESTED") {
+		t.Errorf("evidence should say the preflight was not tested; got:\n%s", sweep.Outputs[0])
+	}
+}
+
+// TestCorsResultFrom covers the tri-state directly: an errored preflight is
+// "not tested", which is a different claim from "no reflection".
+func TestCorsResultFrom(t *testing.T) {
+	errored := attempt.New("preflight")
+	errored.SetError(context.DeadlineExceeded)
+	if got := corsResultFrom(errored); got != corsNotTested {
+		t.Errorf("errored preflight = %v, want corsNotTested", got)
+	}
+
+	absent := attempt.New("preflight")
+	absent.Complete()
+	absent.Metadata[attempt.MetadataKeyOriginValidationAccepted] = false
+	if got := corsResultFrom(absent); got != corsAbsent {
+		t.Errorf("completed non-reflecting preflight = %v, want corsAbsent", got)
+	}
+
+	present := attempt.New("preflight")
+	present.Complete()
+	present.Metadata[attempt.MetadataKeyOriginValidationAccepted] = true
+	if got := corsResultFrom(present); got != corsPresent {
+		t.Errorf("reflecting preflight = %v, want corsPresent", got)
+	}
+
+	if got := corsResultFrom(nil); got != corsNotTested {
+		t.Errorf("nil preflight = %v, want corsNotTested", got)
 	}
 }
 

--- a/internal/probes/mcptransport/originvalidation_test.go
+++ b/internal/probes/mcptransport/originvalidation_test.go
@@ -684,6 +684,80 @@ func TestOriginValidation_UntestedClassIsInconclusive(t *testing.T) {
 	if !strings.Contains(sweepOutput(t, sweep), "that check never ran, so validation cannot be called enforced") {
 		t.Errorf("verdict must not claim enforcement when a whole class went untested; got:\n%s", sweepOutput(t, sweep))
 	}
+
+	// The inconclusive flag alone renders as SAFE (0.5 is not > 0.5), so the
+	// attempt must also be errored to be visibly non-passing. Without this the
+	// metadata says "could not assess" while the row says "safe".
+	if sweep.Status != attempt.StatusError {
+		t.Errorf("sweep status = %q, want %q — an unassessable check must not render as a pass", sweep.Status, attempt.StatusError)
+	}
+	if !strings.Contains(sweep.Error, string(classUnexpectedHost)) {
+		t.Errorf("sweep error should name the untested class; got %q", sweep.Error)
+	}
+}
+
+// TestOriginValidation_TransientFailureIsRetried: a single dropped connection
+// must not be reported as an untested check. It would error the whole sweep,
+// and in Guard a scan with no findings but with probe errors fails the job —
+// so one flake would fail an otherwise-clean scan. Two consecutive failures is
+// the real signal; one is not.
+func TestOriginValidation_TransientFailureIsRetried(t *testing.T) {
+	var mu sync.Mutex
+	seen := map[string]int{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Header.Get("Origin") + "|" + r.Host
+		mu.Lock()
+		seen[key]++
+		n := seen[key]
+		mu.Unlock()
+
+		// Fail the FIRST delivery of every distinct payload, serve the retry.
+		if n == 1 {
+			killConn(t, w)
+			return
+		}
+		if r.Header.Get("Origin") != "" || strings.Contains(r.Host, "example.") {
+			http.Error(w, "not allowed", http.StatusForbidden)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(initializeOK))
+	}))
+	defer srv.Close()
+
+	p := newOriginValidationProbe(t, registry.Config{"endpoint": srv.URL})
+	attempts, err := p.Probe(context.Background(), endpointGen{url: srv.URL, transport: "http"})
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	sweep := findAttemptByClass(attempts, classSweep)
+	if sweep == nil {
+		t.Fatal("expected an aggregated sweep attempt")
+	}
+
+	// Every variant failed once and succeeded on retry, so nothing is untested.
+	if n := variantOutcomes(t, attempts)[variantNotTested]; n != 0 {
+		t.Errorf("%d variants recorded as not-tested; a retried success must count as tested", n)
+	}
+	if sweep.Status == attempt.StatusError {
+		t.Errorf("a sweep whose variants all succeeded on retry must not be errored: %q", sweep.Error)
+	}
+	if metaBool(sweep, attempt.MetadataKeyInconclusive) {
+		t.Errorf("a fully-retried sweep must not be inconclusive")
+	}
+	// Non-vacuity: the server really did drop the first delivery of each payload.
+	mu.Lock()
+	retried := 0
+	for _, n := range seen {
+		if n > 1 {
+			retried++
+		}
+	}
+	mu.Unlock()
+	if retried == 0 {
+		t.Fatal("no payload was retried — the test server did not misbehave as intended")
+	}
 }
 
 // TestOriginValidation_LostSampleIsNotInconclusive: losing SOME variants of a

--- a/internal/probes/mcptransport/originvalidation_test.go
+++ b/internal/probes/mcptransport/originvalidation_test.go
@@ -136,8 +136,11 @@ func corsReflectServer(t *testing.T) *httptest.Server {
 	}))
 }
 
-// findingsByClass runs the detector-side check and returns which bypass
-// classes fired at least one 1.0 score.
+// findingsByClass runs the detector-side check and returns which attempt
+// classes fired at least one 1.0 score. Since LAB-5584 the bypass sweep is a
+// single attempt, so the only classes that can appear here are
+// origin-validation-sweep and cors-reflect-creds — the per-variant classes
+// live inside the sweep attempt's evidence (see acceptedVariantClasses).
 func findingsByClass(attempts []*attempt.Attempt) map[string]bool {
 	det := &originValidationDetectorStub{}
 	fired := map[string]bool{}
@@ -153,8 +156,46 @@ func findingsByClass(attempts []*attempt.Attempt) map[string]bool {
 	return fired
 }
 
-// TestOriginValidation_VulnerableServer: a server with no validation is caught on
-// every non-baseline class.
+// acceptedVariantClasses returns the per-variant classes the aggregated sweep
+// attempt recorded as accepted.
+func acceptedVariantClasses(t *testing.T, attempts []*attempt.Attempt) map[string]bool {
+	t.Helper()
+	sweep := findAttemptByClass(attempts, classSweep)
+	if sweep == nil {
+		t.Fatal("expected an aggregated origin-validation-sweep attempt")
+	}
+	raw, ok := sweep.GetMetadata(attempt.MetadataKeyOriginValidationAcceptedClasses)
+	if !ok {
+		t.Fatal("sweep attempt is missing the accepted-classes metadata")
+	}
+	classes, _ := raw.([]string)
+	got := map[string]bool{}
+	for _, c := range classes {
+		got[c] = true
+	}
+	return got
+}
+
+// sweepVariants returns the per-variant detail recorded on the aggregated
+// sweep attempt.
+func sweepVariants(t *testing.T, attempts []*attempt.Attempt) []map[string]any {
+	t.Helper()
+	sweep := findAttemptByClass(attempts, classSweep)
+	if sweep == nil {
+		t.Fatal("expected an aggregated origin-validation-sweep attempt")
+	}
+	raw, ok := sweep.GetMetadata(attempt.MetadataKeyOriginValidationVariants)
+	if !ok {
+		t.Fatal("sweep attempt is missing the variants metadata")
+	}
+	vs, _ := raw.([]map[string]any)
+	return vs
+}
+
+// TestOriginValidation_VulnerableServer: a server with no validation produces
+// exactly ONE bypass finding, not one per variant — the LAB-5584 fix. Every
+// variant class it accepted must still be recoverable from that one finding's
+// evidence, because "which checks are missing" is what a remediator acts on.
 func TestOriginValidation_VulnerableServer(t *testing.T) {
 	srv := vulnServer(t)
 	defer srv.Close()
@@ -164,11 +205,35 @@ func TestOriginValidation_VulnerableServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Probe: %v", err)
 	}
+
+	// Exactly one attempt scores as a bypass finding. Before LAB-5584 this
+	// was nine.
+	det := &originValidationDetectorStub{}
+	findings := 0
+	for _, a := range attempts {
+		for _, s := range det.detect(a) {
+			if s == 1.0 {
+				findings++
+				break
+			}
+		}
+	}
+	if findings != 1 {
+		t.Errorf("a server that validates nothing must produce 1 finding, got %d (attempts=%d)", findings, len(attempts))
+	}
+
 	fired := findingsByClass(attempts)
+	if !fired[string(classSweep)] {
+		t.Errorf("the aggregated sweep should fire on a fully-vulnerable server; fired=%v", fired)
+	}
+	if fired[string(classBaseline)] {
+		t.Errorf("baseline should never fire as a finding")
+	}
 
 	// httptest binds 127.0.0.1:PORT, so swapCase is a no-op on the host and
 	// the case-variant class is (correctly) skipped — see the
 	// TestOriginValidation_CaseVariantSkippedOnNumericHost test below.
+	acceptedClasses := acceptedVariantClasses(t, attempts)
 	wantClasses := []string{
 		string(classExternalOrigin),
 		string(classNullOrigin),
@@ -177,15 +242,115 @@ func TestOriginValidation_VulnerableServer(t *testing.T) {
 		string(classUnexpectedHost),
 	}
 	for _, c := range wantClasses {
-		if !fired[c] {
-			t.Errorf("class %q should have fired on the fully-vulnerable server (fired=%v)", c, fired)
+		if !acceptedClasses[c] {
+			t.Errorf("variant class %q should be listed as accepted in the sweep evidence (accepted=%v)", c, acceptedClasses)
 		}
 	}
-	if fired[string(classBaseline)] {
-		t.Errorf("baseline should never fire as a finding")
+	if acceptedClasses[string(classCaseVariant)] {
+		t.Errorf("case-variant must NOT be accepted on an all-numeric host (would be an FP)")
 	}
-	if fired[string(classCaseVariant)] {
-		t.Errorf("case-variant must NOT fire on an all-numeric host (would be an FP)")
+}
+
+// TestOriginValidation_SweepEvidenceRecordsEveryVariant: the aggregated
+// finding must account for every crafted value the probe sent, accepted or
+// not. Collapsing ten findings into one is only safe if no evidence is lost.
+func TestOriginValidation_SweepEvidenceRecordsEveryVariant(t *testing.T) {
+	srv := vulnServer(t)
+	defer srv.Close()
+
+	p := newOriginValidationProbe(t, registry.Config{"endpoint": srv.URL})
+	attempts, err := p.Probe(context.Background(), endpointGen{url: srv.URL, transport: "http"})
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	sweep := findAttemptByClass(attempts, classSweep)
+	if sweep == nil {
+		t.Fatal("expected an aggregated sweep attempt")
+	}
+
+	variants := sweepVariants(t, attempts)
+	// Numeric host ⇒ case-variant skipped, so 7 Origin payloads + 2 Host.
+	wantSent := len(p.buildOriginPayloads()) + len(p.buildHostPayloads())
+	if len(variants) != wantSent {
+		t.Errorf("sweep evidence lists %d variants, probe sent %d", len(variants), wantSent)
+	}
+	sent, _ := sweep.GetMetadata(attempt.MetadataKeyOriginValidationVariantsSent)
+	if n, _ := sent.(int); n != wantSent {
+		t.Errorf("variants_sent = %v, want %d", sent, wantSent)
+	}
+	acceptedCount, _ := sweep.GetMetadata(attempt.MetadataKeyOriginValidationVariantsAccepted)
+	if n, _ := acceptedCount.(int); n != wantSent {
+		t.Errorf("variants_accepted = %v, want %d (server validates nothing)", acceptedCount, wantSent)
+	}
+
+	// Every variant carries the header it sent and a response line, so the
+	// evidence stands on its own without the old per-variant attempts.
+	for i, v := range variants {
+		if _, hasOrigin := v["origin"]; !hasOrigin {
+			if _, hasHost := v["host"]; !hasHost {
+				t.Errorf("variant %d records neither origin nor host: %v", i, v)
+			}
+		}
+		if s, _ := v["result"].(string); s == "" {
+			t.Errorf("variant %d has no result line: %v", i, v)
+		}
+	}
+	if len(sweep.Outputs) != 1 {
+		t.Errorf("aggregated attempt should carry exactly one evidence output, got %d", len(sweep.Outputs))
+	}
+	if !strings.Contains(sweep.Outputs[0], "NO Origin/Host validation is enforced") {
+		t.Errorf("evidence should state the validator verdict for an any-origin server; got:\n%s", sweep.Outputs[0])
+	}
+}
+
+// TestOriginValidation_PartialValidationStillOneFinding: a server that refuses
+// some variants and accepts others is still ONE finding, and the evidence
+// distinguishes which checks are missing.
+func TestOriginValidation_PartialValidationStillOneFinding(t *testing.T) {
+	// Refuses anything containing "example.com" but happily accepts
+	// "example.net", "null", and extension origins — the shape of a
+	// half-finished allowlist.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Origin"), "example.com") {
+			http.Error(w, "origin not allowed", http.StatusForbidden)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(initializeOK))
+	}))
+	defer srv.Close()
+
+	p := newOriginValidationProbe(t, registry.Config{"endpoint": srv.URL})
+	attempts, err := p.Probe(context.Background(), endpointGen{url: srv.URL, transport: "http"})
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+
+	fired := findingsByClass(attempts)
+	if !fired[string(classSweep)] {
+		t.Fatalf("partial validation must still produce the aggregated finding; fired=%v", fired)
+	}
+
+	sweep := findAttemptByClass(attempts, classSweep)
+	sent, _ := sweep.GetMetadata(attempt.MetadataKeyOriginValidationVariantsSent)
+	got, _ := sweep.GetMetadata(attempt.MetadataKeyOriginValidationVariantsAccepted)
+	sentN, _ := sent.(int)
+	gotN, _ := got.(int)
+	if gotN == 0 || gotN >= sentN {
+		t.Errorf("expected a partial accept (0 < accepted < sent), got accepted=%d sent=%d", gotN, sentN)
+	}
+	if !strings.Contains(sweep.Outputs[0], "validation is PARTIAL") {
+		t.Errorf("evidence should call out partial validation; got:\n%s", sweep.Outputs[0])
+	}
+	// The rejected variants must be visible too — that is what tells a
+	// remediator the allowlist exists and is merely incomplete.
+	if !strings.Contains(sweep.Outputs[0], "REJECTED") {
+		t.Errorf("evidence should list the refused variants; got:\n%s", sweep.Outputs[0])
+	}
+
+	accepted := acceptedVariantClasses(t, attempts)
+	if !accepted[string(classNullOrigin)] {
+		t.Errorf("null-origin got through and should be listed as accepted; accepted=%v", accepted)
 	}
 }
 
@@ -203,14 +368,9 @@ func TestOriginValidation_CaseVariantSkippedOnNumericHost(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Probe: %v", err)
 	}
-	// Look for any attempt whose class is case-variant.
-	for _, a := range attempts {
-		raw, ok := a.GetMetadata(attempt.MetadataKeyOriginValidationClass)
-		if !ok {
-			continue
-		}
-		if s, _ := raw.(string); s == string(classCaseVariant) {
-			t.Errorf("case-variant attempt should be skipped on numeric host; got attempt %v", a.Prompt)
+	for _, v := range sweepVariants(t, attempts) {
+		if s, _ := v["class"].(string); s == string(classCaseVariant) {
+			t.Errorf("case-variant should not be sent on a numeric host; got variant %v", v)
 		}
 	}
 }
@@ -255,17 +415,30 @@ func TestOriginValidation_DefeatsSubstringWAF(t *testing.T) {
 		t.Fatalf("Probe: %v", err)
 	}
 	fired := findingsByClass(attempts)
-	if !fired[string(classExternalOrigin)] {
-		t.Errorf("external-origin bypass should fire against a substring-blocklist server; fired=%v", fired)
+	if !fired[string(classSweep)] {
+		t.Errorf("the sweep should fire against a substring-blocklist server; fired=%v", fired)
+	}
+	if accepted := acceptedVariantClasses(t, attempts); !accepted[string(classExternalOrigin)] {
+		t.Errorf("external-origin should be among the accepted variants; accepted=%v", accepted)
 	}
 
 	// Confirm that none of the payloads we sent contained a blocklist token.
-	for _, a := range attempts {
-		raw, ok := a.GetMetadata(attempt.MetadataKeyOriginValidationOrigin)
-		if !ok {
-			continue
+	origins := []string{}
+	for _, v := range sweepVariants(t, attempts) {
+		if o, ok := v["origin"].(string); ok {
+			origins = append(origins, o)
 		}
-		o, _ := raw.(string)
+	}
+	for _, a := range attempts {
+		if raw, ok := a.GetMetadata(attempt.MetadataKeyOriginValidationOrigin); ok {
+			o, _ := raw.(string)
+			origins = append(origins, o)
+		}
+	}
+	if len(origins) == 0 {
+		t.Fatal("no Origin payloads recorded — the blocklist check would vacuously pass")
+	}
+	for _, o := range origins {
 		for _, tok := range []string{"evil", "attacker", "hack", "malicious"} {
 			if strings.Contains(strings.ToLower(o), tok) {
 				t.Errorf("payload %q contains blocklist token %q — defeats the point of the probe", o, tok)
@@ -288,6 +461,45 @@ func TestOriginValidation_CORSReflectionWithCredsFired(t *testing.T) {
 	fired := findingsByClass(attempts)
 	if !fired[string(classCORSReflectCreds)] {
 		t.Errorf("cors-reflect-creds should fire when the server reflects Origin + Allow-Credentials; fired=%v", fired)
+	}
+
+	// The reflection escalates the aggregated finding's stated impact: without
+	// it a rebound page drives the tool surface blind; with it, it can read the
+	// responses too.
+	sweep := findAttemptByClass(attempts, classSweep)
+	if sweep == nil {
+		t.Fatal("expected an aggregated sweep attempt")
+	}
+	if !metaBool(sweep, attempt.MetadataKeyOriginValidationCredentialedRead) {
+		t.Errorf("sweep attempt should record the credentialed-read escalation")
+	}
+	if !strings.Contains(sweep.Outputs[0], "Credentialed CORS reflection: PRESENT") ||
+		!strings.Contains(sweep.Outputs[0], "READ") {
+		t.Errorf("aggregated evidence should escalate the impact when the preflight reflects credentials; got:\n%s", sweep.Outputs[0])
+	}
+}
+
+// TestOriginValidation_NoCORSReflectionStatesLesserImpact: the escalation must
+// be conditional — a server without credentialed reflection gets the lesser
+// "blind" impact statement, so the escalated wording stays meaningful.
+func TestOriginValidation_NoCORSReflectionStatesLesserImpact(t *testing.T) {
+	srv := vulnServer(t)
+	defer srv.Close()
+
+	p := newOriginValidationProbe(t, registry.Config{"endpoint": srv.URL})
+	attempts, err := p.Probe(context.Background(), endpointGen{url: srv.URL, transport: "http"})
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	sweep := findAttemptByClass(attempts, classSweep)
+	if sweep == nil {
+		t.Fatal("expected an aggregated sweep attempt")
+	}
+	if metaBool(sweep, attempt.MetadataKeyOriginValidationCredentialedRead) {
+		t.Errorf("vulnServer sets no CORS headers; credentialed-read should be false")
+	}
+	if !strings.Contains(sweep.Outputs[0], "Credentialed CORS reflection: absent") {
+		t.Errorf("evidence should state the lesser impact without reflection; got:\n%s", sweep.Outputs[0])
 	}
 }
 
@@ -331,8 +543,45 @@ func TestOriginValidation_SSEStreamServed(t *testing.T) {
 		t.Fatalf("Probe: %v", err)
 	}
 	fired := findingsByClass(attempts)
-	if !fired[string(classExternalOrigin)] {
-		t.Errorf("external-origin should fire on an SSE endpoint serving any Origin; fired=%v", fired)
+	if !fired[string(classSweep)] {
+		t.Errorf("the sweep should fire on an SSE endpoint serving any Origin; fired=%v", fired)
+	}
+	if accepted := acceptedVariantClasses(t, attempts); !accepted[string(classExternalOrigin)] {
+		t.Errorf("external-origin should be among the accepted variants on SSE; accepted=%v", accepted)
+	}
+}
+
+// TestOriginValidation_AllVariantsFailedIsErrorNotSafe: when every request
+// dies in transit the endpoint was never actually tested. Aggregation must not
+// turn that into a green SAFE row — the whole point of one finding per
+// endpoint is that the one row is trustworthy.
+func TestOriginValidation_AllVariantsFailedIsErrorNotSafe(t *testing.T) {
+	srv := vulnServer(t)
+	url := srv.URL
+	srv.Close() // nothing is listening now; every request fails to connect
+
+	p := newOriginValidationProbe(t, registry.Config{"endpoint": url})
+	attempts, err := p.Probe(context.Background(), endpointGen{url: url, transport: "http"})
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	sweep := findAttemptByClass(attempts, classSweep)
+	if sweep == nil {
+		t.Fatal("expected an aggregated sweep attempt even when every variant failed")
+	}
+	if sweep.Status != attempt.StatusError {
+		t.Errorf("sweep status = %q, want %q — a dead endpoint must not report as safe", sweep.Status, attempt.StatusError)
+	}
+	if sweep.Error == "" {
+		t.Errorf("sweep should carry the transport error")
+	}
+	if _, ok := sweep.GetMetadata(attempt.MetadataKeyOriginValidationAccepted); ok {
+		t.Errorf("sweep must not claim an accept/reject verdict when nothing was tested")
+	}
+	// The evidence still names every variant that could not be tested, so the
+	// operator can see the sweep was not silently truncated.
+	if !strings.Contains(sweep.Outputs[0], "NOT TESTED") {
+		t.Errorf("evidence should list the untested variants; got:\n%s", sweep.Outputs[0])
 	}
 }
 
@@ -402,11 +651,20 @@ func TestOriginValidation_UsesBorrowedHTTPClient(t *testing.T) {
 	if seenCount == 0 {
 		t.Fatalf("recording transport saw NO requests — probe built its own client and bypassed the generator")
 	}
-	// Strict one-to-one: every probe attempt corresponds to exactly one
-	// recorded request. Anything less proves the probe made a side-channel
-	// request bypassing the borrowed client. Fixes CodeRabbit #8.
-	if seenCount != len(attempts) {
-		t.Errorf("attempts=%d, seen=%d — not every request used the borrowed client (side-channel HTTP)", len(attempts), seenCount)
+	// Strict one-to-one against the requests the probe actually made. Since
+	// LAB-5584 that is no longer len(attempts) — the sweep's variants share a
+	// single attempt — so count them from the sweep's own record: baseline +
+	// every variant + the preflight. Anything less proves the probe made a
+	// side-channel request bypassing the borrowed client. Fixes CodeRabbit #8.
+	sweep := findAttemptByClass(attempts, classSweep)
+	if sweep == nil {
+		t.Fatal("expected an aggregated sweep attempt")
+	}
+	raw, _ := sweep.GetMetadata(attempt.MetadataKeyOriginValidationVariantsSent)
+	variantsSent, _ := raw.(int)
+	wantRequests := 1 + variantsSent + 1 // baseline + sweep variants + preflight
+	if seenCount != wantRequests {
+		t.Errorf("requests=%d, seen=%d — not every request used the borrowed client (side-channel HTTP)", wantRequests, seenCount)
 	}
 }
 

--- a/pkg/attempt/metadata_keys.go
+++ b/pkg/attempt/metadata_keys.go
@@ -178,7 +178,9 @@ const (
 	// Set on the aggregated sweep attempt because it escalates that finding's
 	// impact: without it a rebound page drives the tool surface blind; with it
 	// the page can also read the responses.
-	MetadataKeyOriginValidationCredentialedRead = "mcptool.originvalidation_credentialed_read"
+	// Omitted entirely when the preflight did not complete — recording false
+	// there would assert an absence the probe never observed.
+	MetadataKeyOriginValidationCredentialedRead = "mcptool.originvalidation_credentialed_read" // #nosec G101 -- metadata key name, not a credential
 
 	// MetadataKeySSESessionAccepted (bool) records whether an SSE session-
 	// hijack probe attempt succeeded (weakness confirmed). Read by the

--- a/pkg/attempt/metadata_keys.go
+++ b/pkg/attempt/metadata_keys.go
@@ -97,14 +97,23 @@ const (
 	// the expected Origin/Host validation. Values are stable strings suitable
 	// for grouping in a finding report:
 	//
+	//	origin-validation-sweep  the aggregated Origin/Host bypass finding for the
+	//	                         endpoint; carries every crafted value it accepted
+	//	                         as evidence (see MetadataKeyOriginValidationVariants)
+	//	cors-reflect-creds       server reflected the attacker Origin AND allow-credentials in an OPTIONS preflight
+	//	baseline                 spec-compliant baseline (missing Origin) — informational, not a finding
+	//
+	// The per-variant classes below are NOT attempt classes. They label the
+	// individual crafted values inside the aggregated attempt's variant list;
+	// a server that validates nothing accepts all of them, so emitting one
+	// attempt per variant reported a single flaw as ten findings (LAB-5584):
+	//
 	//	external-origin        server accepted a plausibly-external Origin (root cause)
 	//	null-origin            server accepted Origin: null (sandbox iframes, file://)
 	//	extension-origin       server accepted a chrome-extension://[uuid] Origin
 	//	localhost-lookalike    server accepted an Origin that spoofs "localhost" (weak substring/prefix validator)
 	//	case-variant           server accepted a case-shifted variant of the expected host
 	//	unexpected-host        server processed a request bearing a non-canonical Host header
-	//	cors-reflect-creds     server reflected the attacker Origin AND allow-credentials in an OPTIONS preflight
-	//	baseline               spec-compliant baseline (missing Origin) — informational, not a finding
 	MetadataKeyOriginValidationClass = "mcptool.originvalidation_class"
 	// MetadataKeyOriginValidationOrigin (string) is the Origin header value sent.
 	MetadataKeyOriginValidationOrigin = "mcptool.originvalidation_origin"
@@ -137,6 +146,39 @@ const (
 	// loopback/lan and InconclusiveScore (spec violation but
 	// exploitability depends on deployment) on public/unresolvable.
 	MetadataKeyOriginValidationTargetClass = "mcptool.originvalidation_target_class"
+	// MetadataKeyOriginValidationVariants ([]map[string]any) carries the
+	// per-variant detail of the aggregated Origin/Host sweep — one entry per
+	// crafted value the probe sent, each with:
+	//
+	//	class     the per-variant class (external-origin, null-origin, ...)
+	//	origin    the Origin header sent, when the variant set one
+	//	host      the Host header sent, when the variant set one
+	//	accepted  whether the server served the request it should have refused
+	//	result    one-line response summary ("HTTP 200, application/json") or
+	//	          the transport error when the request never completed
+	//
+	// Which variants pass is what tells a remediator whether validation is
+	// absent or merely weak — a case-variant-only bypass is a different bug
+	// from accepting any origin — so the detail is preserved even though the
+	// whole sweep scores as one finding.
+	MetadataKeyOriginValidationVariants = "mcptool.originvalidation_variants"
+	// MetadataKeyOriginValidationAcceptedClasses ([]string) lists the distinct
+	// per-variant classes the endpoint accepted, in sweep order. The fast
+	// grouping key for a report that doesn't want to walk the variant list.
+	MetadataKeyOriginValidationAcceptedClasses = "mcptool.originvalidation_accepted_classes"
+	// MetadataKeyOriginValidationVariantsSent (int) is how many crafted
+	// Origin/Host values the sweep sent.
+	MetadataKeyOriginValidationVariantsSent = "mcptool.originvalidation_variants_sent"
+	// MetadataKeyOriginValidationVariantsAccepted (int) is how many of those
+	// the endpoint accepted. Equal to sent means no validation is enforced at
+	// all; between 1 and sent means partial validation.
+	MetadataKeyOriginValidationVariantsAccepted = "mcptool.originvalidation_variants_accepted"
+	// MetadataKeyOriginValidationCredentialedRead (bool) records whether the
+	// CORS preflight found credentialed reflection of the attacker Origin.
+	// Set on the aggregated sweep attempt because it escalates that finding's
+	// impact: without it a rebound page drives the tool surface blind; with it
+	// the page can also read the responses.
+	MetadataKeyOriginValidationCredentialedRead = "mcptool.originvalidation_credentialed_read"
 
 	// MetadataKeySSESessionAccepted (bool) records whether an SSE session-
 	// hijack probe attempt succeeded (weakness confirmed). Read by the

--- a/pkg/attempt/metadata_keys.go
+++ b/pkg/attempt/metadata_keys.go
@@ -153,7 +153,12 @@ const (
 	//	class     the per-variant class (external-origin, null-origin, ...)
 	//	origin    the Origin header sent, when the variant set one
 	//	host      the Host header sent, when the variant set one
-	//	accepted  whether the server served the request it should have refused
+	//	outcome   "accepted" (server served a request it should have refused),
+	//	          "refused" (server rejected it), or "not-tested" (the request
+	//	          never completed). A tri-state, not a bool: "refused" is
+	//	          evidence of validation and "not-tested" is the absence of
+	//	          evidence, and conflating them lets an untested variant read
+	//	          as a clean result.
 	//	result    one-line response summary ("HTTP 200, application/json") or
 	//	          the transport error when the request never completed
 	//

--- a/pkg/attempt/metadata_keys.go
+++ b/pkg/attempt/metadata_keys.go
@@ -178,6 +178,21 @@ const (
 	// the endpoint accepted. Equal to sent means no validation is enforced at
 	// all; between 1 and sent means partial validation.
 	MetadataKeyOriginValidationVariantsAccepted = "mcptool.originvalidation_variants_accepted"
+	// MetadataKeyOriginValidationBaselineAccepted (bool) records whether the
+	// endpoint served the plain no-Origin baseline request.
+	//
+	// This is the fact that makes every other refusal in the sweep
+	// interpretable. When it is false the endpoint is refusing the CALLER, not
+	// the Origin — an auth gate, an IP allowlist and a dead backend are
+	// indistinguishable from Origin enforcement to an outside observer — so
+	// refusals of the crafted values are NOT evidence that a validator exists.
+	// The detector reads this to score such a sweep inconclusive rather than
+	// clean.
+	MetadataKeyOriginValidationBaselineAccepted = "mcptool.originvalidation_baseline_accepted"
+	// MetadataKeyOriginValidationUntestedClasses ([]string) lists the bypass
+	// classes for which NOT ONE variant got a response — checks that never ran,
+	// as opposed to a class that was exercised and merely lost a sample.
+	MetadataKeyOriginValidationUntestedClasses = "mcptool.originvalidation_untested_classes"
 	// MetadataKeyOriginValidationCredentialedRead (bool) records whether the
 	// CORS preflight found credentialed reflection of the attacker Origin.
 	// Set on the aggregated sweep attempt because it escalates that finding's


### PR DESCRIPTION
Fixes LAB-5584

## Problem

`mcptransport.OriginValidation` emitted **one scored attempt per bypass variant**. A server that validates no Origin fails every variant, so a single flaw surfaced as ten identical 1.0 rows.

Per the ticket's corpus measurement: **260 of 308 findings across thirteen HTTP MCP targets — 84% — were this one check.** On one lab it was 100% of the output. On the benign `server-everything` reference server it was 10 of 12 rows, so a server with no vulnerabilities still produced twelve red rows.

The ten variants (two external origins, null, two extension origins, two localhost-lookalikes, a case variant, two unexpected Hosts) are ten ways of asking one question — does this endpoint enforce the Origin/Host allowlist the spec requires — and a server that validates nothing answers all ten identically.

The check itself is sound and stays: the finding is real, the loopback/LAN vs public severity tiering is well reasoned, and the CORS half is already separated. The defect was purely that ten proofs of one property were presented as ten vulnerabilities.

## Guard was checked first, per the ticket

`emitPerProbeRisks` in Guard (`backend/pkg/tasks/capabilities/augustus/augustus.go`) already buckets findings **by probe name** and emits one risk per probe. The ten attempts have always collapsed to one `llm-mcptransport-originvalidation` risk, so the customer-facing risk count was never wrong.

What was wrong Guard-side is the **proof attachment** on that single risk: ten near-identical `ScanFindings` blobs. This change makes it one legible finding. No Guard change is needed — `evidenceFromMetadata` copies attempt metadata verbatim, so the new keys flow through untouched, and nothing in the Guard backend or frontend is coupled to the class values (grepped).

## Change

One scored attempt for the endpoint (class `origin-validation-sweep`) carrying every crafted value as evidence.

Per-variant detail is preserved deliberately — which variants pass is what a remediator acts on. A case-variant-only bypass means the allowlist exists but compares case-sensitively; that's a different fix from an endpoint that accepts any origin.

```
[origin-validation-sweep] 7 of 9 crafted Origin/Host values accepted

Validator verdict: validation is PARTIAL — the accepted classes below are the checks that are missing

ACCEPTED — served a request it should have refused
  [external-origin] Origin=https://cdn-bbd41350.example.net    -> HTTP 200, application/json
  [null-origin] Origin=null                                    -> HTTP 200, application/json
  ...
REJECTED — refused as a hardened server should
  [external-origin] Origin=https://bbd41350.example.com        -> HTTP 403, text/plain
  ...

Credentialed CORS reflection: PRESENT. ... it can also READ the responses ...

Representative accepted exchange (...): POST ... -> HTTP 200 ...
```

- **Baseline and preflight attempts unchanged**, as the ticket asked.
- **Host-class severity tiering unchanged** — the sweep carries the same target-class stamp, so the detector needed no logic change.
- **Credentialed CORS reflection escalates the aggregated impact** from "a page can drive the tool surface blind" to "a page can also read the responses", conditionally, plus a `credentialed_read` metadata key.
- New metadata: `..._variants` (structured per-variant list), `..._accepted_classes`, `..._variants_sent`, `..._variants_accepted`, `..._credentialed_read`.

### One judgement call worth reviewing

When **every** variant dies in transit, the sweep now reports as **errored** rather than safe. Collapsing to one row is only sound if that row is trustworthy, and a dead endpoint reporting SAFE would be worse than the noise this removes. Test locks it in.

## Verification

Built the binary before and after the change and ran both against the live DVMCP corpus (challenges 1-10, legacy SSE transport):

| | BEFORE | AFTER |
|---|---|---|
| findings | **90** | **10** |
| attempts | 110 | 30 |

Every challenge went 9 findings → 1 (nine not ten because these bind `127.0.0.1:900X`, an all-numeric host where the case variant is correctly skipped as a would-be FP).

**No information lost** — machine-checked that the set of variant classes in the nine BEFORE findings is identical to the set in the one AFTER finding's evidence, on all ten challenges.

**Negative control:** the DVMCP streamable-HTTP servers (mcp 1.28.1, hardened because FastMCP auto-enables DNS-rebinding protection when constructed with the default loopback host) score clean both before and after, and the aggregated evidence states it positively — *"every crafted value was refused — Origin/Host validation is enforced."* So the collapse doesn't manufacture a finding where there isn't one, and a hardened server reads as one green row instead of eleven.

Note the corpus here is the SSE half of DVMCP only, not the ticket's full thirteen targets, so this doesn't reproduce its exact 230-finding projection.

`go build ./...`, full `go test ./...`, `gofmt`, and `golangci-lint` (0 issues) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)