### PR TITLE
feat(toolargs): per-tool argument hints for uniform-envelope MCP servers

### DIFF
--- a/internal/probes/mcptool/injection.go
+++ b/internal/probes/mcptool/injection.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/praetorian-inc/augustus/internal/mcpprobe"
+	"github.com/praetorian-inc/augustus/internal/toolargs"
 	"github.com/praetorian-inc/augustus/internal/toolpolicy"
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/probes"
@@ -41,8 +42,11 @@ var (
 // The target must implement types.ToolInvoker; other targets are skipped.
 type Injection struct {
 	reconContext
-	canary       mcpprobe.Canary
-	policy       toolpolicy.Policy
+	canary mcpprobe.Canary
+	policy toolpolicy.Policy
+	// args carries the operator\'s per-tool argument hints (tool_args /
+	// tool_id_paths). Empty by default, leaving synthesized arguments unchanged.
+	args         toolargs.Builder
 	listen       string        // OOB collector bind address
 	baseOverride string        // URL the target should use to reach the collector (optional)
 	wait         time.Duration // grace period for callbacks after sending
@@ -57,6 +61,7 @@ func NewInjection(cfg registry.Config) (probes.Prober, error) {
 	return &Injection{
 		canary:       mcpprobe.NewCanary(),
 		policy:       toolpolicy.New(cfg),
+		args:         toolargs.New(cfg),
 		listen:       registry.GetString(cfg, "oob_listen", "127.0.0.1:0"),
 		baseOverride: registry.GetString(cfg, "oob_base_url", ""),
 		wait:         time.Duration(registry.GetInt(cfg, "oob_wait_seconds", 3)) * time.Second,
@@ -224,7 +229,7 @@ func (p *Injection) callOne(ctx context.Context, inv types.ToolInvoker, tool, pa
 	a.Metadata["mcptool.tool"] = tool
 	a.Metadata["mcptool.param"] = param
 
-	res, err := inv.CallTool(ctx, tool, benignArgs(params, param, payload))
+	res, err := inv.CallTool(ctx, tool, buildArgs(p.args, tool, params, param, payload))
 	if err != nil {
 		a.SetError(err)
 		return a
@@ -256,7 +261,7 @@ func (p *Injection) callOOB(ctx context.Context, inv types.ToolInvoker, tool, pa
 	a.Metadata["mcptool.tool"] = tool
 	a.Metadata["mcptool.param"] = param
 
-	res, err := inv.CallTool(ctx, tool, benignArgs(params, param, payload))
+	res, err := inv.CallTool(ctx, tool, buildArgs(p.args, tool, params, param, payload))
 	if err != nil {
 		a.SetError(err)
 		return a

--- a/internal/probes/mcptool/mcptool.go
+++ b/internal/probes/mcptool/mcptool.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/praetorian-inc/augustus/internal/toolargs"
 	"github.com/praetorian-inc/augustus/pkg/types"
 )
 
@@ -263,6 +264,21 @@ func mineCandidateValuesExcluding(frag string, exclude map[string]bool) []string
 // type is treated as string-injectable (schemas in the wild often omit it).
 func isStringParam(typ string) bool {
 	return typ == "" || typ == "string"
+}
+
+// buildArgs assembles the arguments for one probe call: the schema-derived
+// baseline from benignArgs, then the operator's per-tool hints applied on top —
+// the payload relocated to a nested path when tool_id_paths names one, and static
+// values merged over fillers the schema cannot supply (a tenant id, an account
+// uid). With no hints configured this is exactly benignArgs.
+//
+// It exists for servers that wrap every tool behind a uniform envelope, where a
+// synthesized flat call is rejected by argument validation before the sink under
+// test is ever reached — which would otherwise be reported as a SAFE target.
+func buildArgs(b toolargs.Builder, tool string, params []paramInfo, injectParam, payload string) map[string]any {
+	args := benignArgs(params, injectParam, payload)
+	args = b.Place(tool, injectParam, payload, args)
+	return b.Apply(tool, args)
 }
 
 // benignArgs builds a call argument map: the injected payload in injectParam, and

--- a/internal/probes/mcptool/pathtraversal.go
+++ b/internal/probes/mcptool/pathtraversal.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/praetorian-inc/augustus/internal/mcpprobe"
+	"github.com/praetorian-inc/augustus/internal/toolargs"
 	"github.com/praetorian-inc/augustus/internal/toolpolicy"
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/probes"
@@ -165,6 +166,9 @@ type PathTraversal struct {
 	// never tools whose read intent was inferred from name and description.
 	requireReadOnlyAnnotation bool
 	policy                    toolpolicy.Policy
+	// args carries the operator\'s per-tool argument hints (tool_args /
+	// tool_id_paths). Empty by default, leaving synthesized arguments unchanged.
+	args toolargs.Builder
 }
 
 // NewPathTraversal reads pathtraversal_all_string_params + the shared
@@ -174,6 +178,7 @@ func NewPathTraversal(cfg registry.Config) (probes.Prober, error) {
 		allParams:                 registry.GetBool(cfg, "pathtraversal_all_string_params", false),
 		requireReadOnlyAnnotation: registry.GetBool(cfg, "pathtraversal_require_readonly_annotation", false),
 		policy:                    toolpolicy.New(cfg),
+		args:                      toolargs.New(cfg),
 	}, nil
 }
 
@@ -510,7 +515,7 @@ func (p *PathTraversal) callOne(ctx context.Context, inv types.ToolInvoker, tool
 		a.Metadata[attempt.MetadataKeyPathTraversalIsWrite] = true
 	}
 
-	res, err := inv.CallTool(ctx, tool, benignArgs(params, param, tp.payload))
+	res, err := inv.CallTool(ctx, tool, buildArgs(p.args, tool, params, param, tp.payload))
 	if err != nil {
 		a.SetError(err)
 		return a

--- a/internal/probes/mcptool/ssrf.go
+++ b/internal/probes/mcptool/ssrf.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/praetorian-inc/augustus/internal/mcpprobe"
+	"github.com/praetorian-inc/augustus/internal/toolargs"
 	"github.com/praetorian-inc/augustus/internal/toolpolicy"
 	"github.com/praetorian-inc/augustus/pkg/attempt"
 	"github.com/praetorian-inc/augustus/pkg/probes"
@@ -44,6 +45,9 @@ type SSRF struct {
 	allParams    bool              // inject into every string param, not just URL-like ones
 	marker       string            // collector body marker (reflection signal)
 	policy       toolpolicy.Policy // destructive-tool safety gate
+	// args carries the operator\'s per-tool argument hints (tool_args /
+	// tool_id_paths). Empty by default, leaving synthesized arguments unchanged.
+	args toolargs.Builder
 }
 
 // NewSSRF constructs the probe. All OOB settings default so a localhost target
@@ -56,6 +60,7 @@ func NewSSRF(cfg registry.Config) (probes.Prober, error) {
 		allParams:    registry.GetBool(cfg, "ssrf_all_string_params", false),
 		marker:       "AUGOOB" + mcpprobe.RandToken(),
 		policy:       toolpolicy.New(cfg),
+		args:         toolargs.New(cfg),
 	}, nil
 }
 
@@ -188,7 +193,7 @@ func (p *SSRF) Probe(ctx context.Context, gen types.Generator) ([]*attempt.Attem
 				a.Metadata[attempt.MetadataKeySSRFOOBURL] = canaryURL
 
 				reflected := false
-				res, callErr := inv.CallTool(ctx, name, benignArgs(params, param.name, payload))
+				res, callErr := inv.CallTool(ctx, name, buildArgs(p.args, name, params, param.name, payload))
 				if callErr != nil {
 					a.SetError(callErr)
 				} else {

--- a/internal/recon/mcp/identifiers.go
+++ b/internal/recon/mcp/identifiers.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/praetorian-inc/augustus/internal/recon/llm"
+	"github.com/praetorian-inc/augustus/internal/toolargs"
 	"github.com/praetorian-inc/augustus/internal/toolpolicy"
 	"github.com/praetorian-inc/augustus/pkg/generators"
 	"github.com/praetorian-inc/augustus/pkg/output"
@@ -74,6 +75,14 @@ type MCPIdentifiers struct {
 	// benign/id args. Replaces the old destructive-NAME regex heuristic.
 	policy toolpolicy.Policy
 
+	// args carries the operator's per-tool argument hints (tool_args /
+	// tool_id_paths). Empty by default, in which case call arguments are
+	// synthesized from the schema exactly as before. It exists for servers that
+	// wrap every tool behind a uniform envelope, where a required top-level
+	// parameter (a tenant id) cannot be inferred from the schema and the object
+	// identifier belongs inside a nested object rather than at the top level.
+	args toolargs.Builder
+
 	// Compiled from the (operator-extendable) keyword vocabularies.
 	idParamRE *regexp.Regexp
 	getterRE  *regexp.Regexp
@@ -104,6 +113,7 @@ func NewIdentifiers(cfg registry.Config) (recon.Recon, error) {
 		useNavigator:     registry.GetBool(cfg, "use_navigator", true),
 		maxIDsPerTool:    registry.GetInt(cfg, "max_ids_per_tool", 5),
 		policy:           toolpolicy.New(cfg),
+		args:             toolargs.New(cfg),
 		idParamRE:        wordBoundaryRE(resolvePatterns(cfg, "id_param_patterns", "id_param_extra_patterns", defaultIDParamWords)),
 		getterRE:         wordBoundaryRE(resolvePatterns(cfg, "getter_name_patterns", "getter_name_extra_patterns", defaultGetterWords)),
 		enumRE:           wordBoundaryRE(resolvePatterns(cfg, "enum_name_patterns", "enum_name_extra_patterns", defaultEnumWords)),
@@ -467,7 +477,7 @@ func (m *MCPIdentifiers) harvestAndValidate(ctx context.Context, s identitySessi
 			slog.Warn("recon.MCPIdentifiers: not invoking classified enumerator (call-site policy gate)", "tool", en.name, "reason", reason)
 			continue
 		}
-		res, err := s.inv.CallTool(ctx, en.name, requiredBenignArgs(en.params))
+		res, err := s.inv.CallTool(ctx, en.name, m.args.Apply(en.name, requiredBenignArgs(en.params)))
 		if err != nil || res.IsError {
 			continue
 		}
@@ -497,7 +507,7 @@ func (m *MCPIdentifiers) harvestAndValidate(ctx context.Context, s identitySessi
 			if confirmed[key] {
 				continue
 			}
-			args := benignArgs(g.params, g.idParam, cand.id)
+			args := m.buildGetterArgs(g, cand.id)
 			res, err := s.inv.CallTool(ctx, g.name, args)
 			if err != nil || res.IsError || strings.TrimSpace(res.Text) == "" {
 				continue
@@ -585,6 +595,20 @@ func paramRequired(params []toolParam, name string) bool {
 		}
 	}
 	return false
+}
+
+// buildGetterArgs assembles the arguments for one getter call: the schema-derived
+// baseline (identifier in idParam, benign fillers elsewhere), then the operator's
+// per-tool hints applied on top — the identifier relocated to a nested path when
+// tool_id_paths names one, and static values merged over fillers the schema
+// cannot supply. With no hints configured this is exactly benignArgs.
+//
+// The result is stored verbatim on the emitted MCPObjectRef.Args, so a
+// downstream BOLA replay reuses the same validated envelope.
+func (m *MCPIdentifiers) buildGetterArgs(g toolSpec, id string) map[string]any {
+	args := benignArgs(g.params, g.idParam, id)
+	args = m.args.Place(g.name, g.idParam, id, args)
+	return m.args.Apply(g.name, args)
 }
 
 // benignArgs builds a call argument map: the identifier in idParam plus benign

--- a/internal/recon/mcp/identifiers_toolargs_test.go
+++ b/internal/recon/mcp/identifiers_toolargs_test.go
@@ -1,0 +1,124 @@
+package mcp
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/praetorian-inc/augustus/pkg/registry"
+)
+
+// envelopeGetter models the uniform-envelope tool shape that motivates the
+// tool_args / tool_id_paths hints: two required top-level parameters that must be
+// exactly right (a discriminator and an opaque tenant id) plus a nested object
+// that carries the real arguments.
+func envelopeGetter() toolSpec {
+	return toolSpec{
+		name: "upwork__get_account",
+		params: []toolParam{
+			{name: "action", typ: "string", required: true},
+			{name: "org_uid", typ: "string", required: true},
+			{name: "params", typ: "object", required: false},
+		},
+		idParam: "id",
+	}
+}
+
+func newIdentifiers(t *testing.T, cfg registry.Config) *MCPIdentifiers {
+	t.Helper()
+	r, err := NewIdentifiers(cfg)
+	if err != nil {
+		t.Fatalf("NewIdentifiers: %v", err)
+	}
+	m, ok := r.(*MCPIdentifiers)
+	if !ok {
+		t.Fatalf("NewIdentifiers returned %T, want *MCPIdentifiers", r)
+	}
+	return m
+}
+
+// Without hints, buildGetterArgs must be byte-for-byte what benignArgs produced
+// before this change: no existing target's behavior shifts.
+func TestBuildGetterArgsUnchangedWithoutHints(t *testing.T) {
+	m := newIdentifiers(t, registry.Config{})
+	g := envelopeGetter()
+
+	got := m.buildGetterArgs(g, "TARGET")
+	want := benignArgs(g.params, g.idParam, "TARGET")
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildGetterArgs = %v, want benignArgs output %v", got, want)
+	}
+	// Documents the pre-fix shape that the server rejects: placeholders in the
+	// required discriminator/tenant params, identifier stranded at the top level.
+	if got["action"] != "test" || got["org_uid"] != "test" {
+		t.Errorf("expected synthesized placeholders, got %v", got)
+	}
+	if _, nested := got["params"]; nested {
+		t.Errorf("params should not be populated without hints: %v", got)
+	}
+}
+
+// With both hints, the same getter yields the envelope the server accepts.
+func TestBuildGetterArgsAppliesEnvelopeHints(t *testing.T) {
+	m := newIdentifiers(t, registry.Config{
+		"tool_args": map[string]any{
+			"upwork__get_account": map[string]any{
+				"action":  "get_user_details",
+				"org_uid": "2087392690628212517",
+			},
+		},
+		"tool_id_paths": map[string]any{
+			"upwork__get_account": "params.id",
+		},
+	})
+
+	got := m.buildGetterArgs(envelopeGetter(), "VICTIM_ID")
+	want := map[string]any{
+		"action":  "get_user_details",
+		"org_uid": "2087392690628212517",
+		"params":  map[string]any{"id": "VICTIM_ID"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildGetterArgs = %v, want %v", got, want)
+	}
+	if _, flat := got["id"]; flat {
+		t.Errorf("identifier left at top level: %v", got)
+	}
+}
+
+// tool_args alone (no id path) still fixes the required discriminator/tenant
+// params while leaving the caller's flat identifier placement intact — the right
+// behavior for a server whose id genuinely is top level.
+func TestBuildGetterArgsStaticOnlyKeepsFlatIdentifier(t *testing.T) {
+	m := newIdentifiers(t, registry.Config{
+		"tool_args": map[string]any{
+			"upwork__get_account": map[string]any{"action": "get_user_details"},
+		},
+	})
+
+	got := m.buildGetterArgs(envelopeGetter(), "TARGET")
+	if got["action"] != "get_user_details" {
+		t.Errorf("action = %v, want get_user_details", got["action"])
+	}
+	if got["id"] != "TARGET" {
+		t.Errorf("id = %v, want TARGET at top level", got["id"])
+	}
+	if got["org_uid"] != "test" {
+		t.Errorf("org_uid = %v, want untouched placeholder", got["org_uid"])
+	}
+}
+
+// Hints are per tool: a tool with no entry is unaffected by another's.
+func TestBuildGetterArgsHintsAreScopedPerTool(t *testing.T) {
+	m := newIdentifiers(t, registry.Config{
+		"tool_args":     map[string]any{"other_tool": map[string]any{"action": "x"}},
+		"tool_id_paths": map[string]any{"other_tool": "params.id"},
+	})
+	g := envelopeGetter()
+
+	got := m.buildGetterArgs(g, "TARGET")
+	want := benignArgs(g.params, g.idParam, "TARGET")
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildGetterArgs = %v, want unchanged %v", got, want)
+	}
+}

--- a/internal/toolargs/toolargs.go
+++ b/internal/toolargs/toolargs.go
@@ -1,0 +1,163 @@
+// Package toolargs resolves operator-supplied argument overrides for MCP tool
+// calls.
+//
+// Recon modules and tool-security probes synthesize call arguments from a tool's
+// JSON schema: an identifier (or payload) in the parameter under test, plus a
+// filler for every other required parameter. That works when the required
+// parameters are either the identifier itself or incidental (limit, format), and
+// it is the right default — it needs no configuration and no prior knowledge of
+// the target.
+//
+// It breaks on servers that wrap every tool behind a uniform envelope. A
+// real-world shape:
+//
+//	{"action": "<enum>", "org_uid": "<tenant id>", "params": {...}}
+//
+// Here BOTH required top-level parameters must be exactly right — the tenant id
+// is an opaque value no schema declares — and the parameter actually under test
+// (an object id) lives nested inside `params`, not at the top level. A
+// synthesized flat call is rejected by argument validation before the server
+// logic runs, so the caller records an error and moves on: recon harvests no
+// identifiers, and a probe reports the target SAFE without ever reaching the
+// code it meant to exercise. A silently narrowed scan, not a clean one.
+//
+// Builder closes that gap with two operator-supplied hints per tool:
+//
+//	tool_args      — static values merged OVER the synthesized arguments, for
+//	                 parameters whose correct value cannot be inferred from the
+//	                 schema (a tenant id, an account uid, an api version).
+//	tool_id_paths  — a dotted path naming where the identifier/payload belongs,
+//	                 so it can be placed inside a nested object instead of at
+//	                 the top level.
+//
+// Both are optional and default to empty: with no configuration Builder is a
+// no-op and callers keep their existing behavior exactly.
+package toolargs
+
+import (
+	"strings"
+
+	"github.com/praetorian-inc/augustus/pkg/registry"
+)
+
+const (
+	cfgToolArgs    = "tool_args"
+	cfgToolIDPaths = "tool_id_paths"
+)
+
+// Builder holds the per-tool argument hints for one component (a recon module or
+// a probe). The zero value is a valid no-op Builder.
+type Builder struct {
+	static map[string]map[string]any
+	idPath map[string]string
+}
+
+// New reads the tool_args and tool_id_paths hints from a component's config.
+// Malformed entries are skipped rather than failing construction: a bad hint
+// must not take down a scan that is useful without it.
+func New(cfg registry.Config) Builder {
+	return Builder{
+		static: parseStatic(cfg),
+		idPath: parseIDPaths(cfg),
+	}
+}
+
+// IDPath returns the configured dotted path for the tool's identifier/payload
+// parameter, or "" when the caller should place it at the top level as before.
+func (b Builder) IDPath(tool string) string {
+	return b.idPath[tool]
+}
+
+// Apply merges the tool's configured static arguments over args and returns it.
+// Operator-supplied values win: they exist precisely because the synthesized
+// filler is wrong. args may be nil, in which case a new map is returned when
+// there is anything to add.
+func (b Builder) Apply(tool string, args map[string]any) map[string]any {
+	static := b.static[tool]
+	if len(static) == 0 {
+		return args
+	}
+	if args == nil {
+		args = make(map[string]any, len(static))
+	}
+	for k, v := range static {
+		args[k] = v
+	}
+	return args
+}
+
+// Place puts value at the tool's configured identifier path, removing flatKey
+// (the top-level parameter the caller would otherwise have used). When no path
+// is configured it leaves args untouched, so the caller's own placement stands.
+//
+// Intermediate objects along the path are created as needed. An existing
+// non-object value at an intermediate step is replaced: the configured path is
+// an explicit statement about the tool's shape, so it wins over a synthesized
+// placeholder such as the empty object that fills an `object`-typed parameter.
+func (b Builder) Place(tool, flatKey string, value any, args map[string]any) map[string]any {
+	path := b.idPath[tool]
+	if path == "" || args == nil {
+		return args
+	}
+	delete(args, flatKey)
+	SetPath(args, path, value)
+	return args
+}
+
+// SetPath assigns value at a dotted path within args, creating intermediate
+// objects as needed. A path with no dots is a plain top-level assignment. An
+// empty path is ignored.
+func SetPath(args map[string]any, path string, value any) {
+	if args == nil || path == "" {
+		return
+	}
+	segments := strings.Split(path, ".")
+	cursor := args
+	for _, seg := range segments[:len(segments)-1] {
+		next, ok := cursor[seg].(map[string]any)
+		if !ok {
+			next = map[string]any{}
+			cursor[seg] = next
+		}
+		cursor = next
+	}
+	cursor[segments[len(segments)-1]] = value
+}
+
+// parseStatic reads tool_args: a map of tool name to the argument map to merge
+// over that tool's synthesized arguments.
+func parseStatic(cfg registry.Config) map[string]map[string]any {
+	raw, ok := cfg[cfgToolArgs].(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := make(map[string]map[string]any, len(raw))
+	for tool, v := range raw {
+		if args, ok := v.(map[string]any); ok && len(args) > 0 {
+			out[tool] = args
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// parseIDPaths reads tool_id_paths: a map of tool name to the dotted path where
+// that tool's identifier/payload parameter belongs.
+func parseIDPaths(cfg registry.Config) map[string]string {
+	raw, ok := cfg[cfgToolIDPaths].(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := make(map[string]string, len(raw))
+	for tool, v := range raw {
+		if path, ok := v.(string); ok && path != "" {
+			out[tool] = path
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/toolargs/toolargs_test.go
+++ b/internal/toolargs/toolargs_test.go
@@ -1,0 +1,231 @@
+package toolargs
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/praetorian-inc/augustus/pkg/registry"
+)
+
+// The zero Builder and an empty config must both leave call arguments exactly as
+// the caller synthesized them: every existing target keeps its current behavior.
+func TestNoConfigIsANoOp(t *testing.T) {
+	for name, b := range map[string]Builder{
+		"zero value":   {},
+		"empty config": New(registry.Config{}),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := b.IDPath("tool"); got != "" {
+				t.Fatalf("IDPath = %q, want empty", got)
+			}
+			args := map[string]any{"id": "X", "action": "test"}
+			want := map[string]any{"id": "X", "action": "test"}
+
+			if got := b.Apply("tool", args); !reflect.DeepEqual(got, want) {
+				t.Errorf("Apply mutated args: %v, want %v", got, want)
+			}
+			if got := b.Place("tool", "id", "X", args); !reflect.DeepEqual(got, want) {
+				t.Errorf("Place mutated args: %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// Static args override the synthesized filler: they exist because the schema
+// cannot supply the correct value (an opaque tenant id, an account uid).
+func TestApplyOverridesSynthesizedFillers(t *testing.T) {
+	b := New(registry.Config{
+		"tool_args": map[string]any{
+			"get_account": map[string]any{
+				"action":  "get_user_details",
+				"org_uid": "2087392690628212517",
+			},
+		},
+	})
+
+	got := b.Apply("get_account", map[string]any{
+		"action":  "test", // placeholder the schema produced
+		"org_uid": "test", // placeholder the schema produced
+		"params":  map[string]any{},
+	})
+	want := map[string]any{
+		"action":  "get_user_details",
+		"org_uid": "2087392690628212517",
+		"params":  map[string]any{},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Apply = %v, want %v", got, want)
+	}
+
+	// A tool with no configured entry is untouched.
+	other := map[string]any{"action": "test"}
+	if got := b.Apply("find_jobs", other); !reflect.DeepEqual(got, map[string]any{"action": "test"}) {
+		t.Errorf("unconfigured tool mutated: %v", got)
+	}
+}
+
+func TestApplyOnNilArgs(t *testing.T) {
+	b := New(registry.Config{
+		"tool_args": map[string]any{"t": map[string]any{"k": "v"}},
+	})
+	got := b.Apply("t", nil)
+	if !reflect.DeepEqual(got, map[string]any{"k": "v"}) {
+		t.Errorf("Apply(nil) = %v, want {k:v}", got)
+	}
+	// Nil in, nil out when there is nothing to add.
+	if got := b.Apply("unconfigured", nil); got != nil {
+		t.Errorf("Apply(nil) on unconfigured tool = %v, want nil", got)
+	}
+}
+
+// Place moves the identifier off the top level and into the nested object the
+// server actually reads it from, creating the intermediate object.
+func TestPlaceRelocatesIdentifierIntoNestedObject(t *testing.T) {
+	b := New(registry.Config{
+		"tool_id_paths": map[string]any{"get_account": "params.id"},
+	})
+
+	got := b.Place("get_account", "id", "TARGET", map[string]any{
+		"id":      "TARGET", // flat placement the caller made
+		"action":  "test",
+		"org_uid": "test",
+	})
+	want := map[string]any{
+		"action":  "test",
+		"org_uid": "test",
+		"params":  map[string]any{"id": "TARGET"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Place = %v, want %v", got, want)
+	}
+}
+
+// The synthesized filler for an `object`-typed parameter is an empty map; the
+// configured path must populate it rather than be discarded by it.
+func TestPlacePopulatesExistingEmptyObject(t *testing.T) {
+	b := New(registry.Config{
+		"tool_id_paths": map[string]any{"t": "params.job_id"},
+	})
+	got := b.Place("t", "job_id", "J1", map[string]any{
+		"job_id": "J1",
+		"params": map[string]any{}, // benignValue("object")
+	})
+	want := map[string]any{"params": map[string]any{"job_id": "J1"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Place = %v, want %v", got, want)
+	}
+}
+
+// A non-object value sitting at an intermediate step is replaced: the configured
+// path is an explicit statement about the tool's shape and outranks a filler.
+func TestPlaceReplacesNonObjectIntermediate(t *testing.T) {
+	b := New(registry.Config{
+		"tool_id_paths": map[string]any{"t": "params.id"},
+	})
+	got := b.Place("t", "id", "X", map[string]any{"params": "test"})
+	want := map[string]any{"params": map[string]any{"id": "X"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Place = %v, want %v", got, want)
+	}
+}
+
+func TestPlaceUnconfiguredToolKeepsFlatPlacement(t *testing.T) {
+	b := New(registry.Config{
+		"tool_id_paths": map[string]any{"other": "params.id"},
+	})
+	args := map[string]any{"id": "X"}
+	if got := b.Place("t", "id", "X", args); !reflect.DeepEqual(got, map[string]any{"id": "X"}) {
+		t.Errorf("Place = %v, want flat placement preserved", got)
+	}
+}
+
+func TestSetPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		args map[string]any
+		want map[string]any
+	}{
+		{"top level", "id", map[string]any{}, map[string]any{"id": "V"}},
+		{"one level", "params.id", map[string]any{}, map[string]any{"params": map[string]any{"id": "V"}}},
+		{
+			"deep", "a.b.c",
+			map[string]any{},
+			map[string]any{"a": map[string]any{"b": map[string]any{"c": "V"}}},
+		},
+		{
+			"preserves siblings", "params.id",
+			map[string]any{"params": map[string]any{"limit": 1}},
+			map[string]any{"params": map[string]any{"limit": 1, "id": "V"}},
+		},
+		{"empty path ignored", "", map[string]any{"k": "v"}, map[string]any{"k": "v"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			SetPath(tc.args, tc.path, "V")
+			if !reflect.DeepEqual(tc.args, tc.want) {
+				t.Errorf("SetPath = %v, want %v", tc.args, tc.want)
+			}
+		})
+	}
+}
+
+func TestSetPathOnNilMapDoesNotPanic(t *testing.T) {
+	SetPath(nil, "params.id", "V") // must not panic
+}
+
+// Malformed hints are skipped, not fatal: a bad entry must not disable a scan
+// that is still useful without it.
+func TestMalformedConfigIsSkipped(t *testing.T) {
+	b := New(registry.Config{
+		"tool_args":     map[string]any{"t": "not-a-map", "u": map[string]any{}},
+		"tool_id_paths": map[string]any{"t": 42, "u": ""},
+	})
+	if b.static != nil {
+		t.Errorf("static = %v, want nil", b.static)
+	}
+	if b.idPath != nil {
+		t.Errorf("idPath = %v, want nil", b.idPath)
+	}
+}
+
+func TestWrongTypeConfigIsSkipped(t *testing.T) {
+	b := New(registry.Config{"tool_args": "nope", "tool_id_paths": []string{"nope"}})
+	if b.static != nil || b.idPath != nil {
+		t.Errorf("expected no hints, got static=%v idPath=%v", b.static, b.idPath)
+	}
+}
+
+// The end-to-end shape: a flat synthesized call becomes the envelope the server
+// actually accepts.
+func TestBuilderProducesServerAcceptedEnvelope(t *testing.T) {
+	b := New(registry.Config{
+		"tool_args": map[string]any{
+			"upwork__get_account": map[string]any{
+				"action":  "get_user_details",
+				"org_uid": "2087392690628212517",
+			},
+		},
+		"tool_id_paths": map[string]any{"upwork__get_account": "params.id"},
+	})
+
+	// What a caller synthesizes from the schema today.
+	args := map[string]any{
+		"id":      "VICTIM_ID",
+		"action":  "test",
+		"org_uid": "test",
+		"params":  map[string]any{},
+	}
+
+	args = b.Place("upwork__get_account", "id", "VICTIM_ID", args)
+	args = b.Apply("upwork__get_account", args)
+
+	want := map[string]any{
+		"action":  "get_user_details",
+		"org_uid": "2087392690628212517",
+		"params":  map[string]any{"id": "VICTIM_ID"},
+	}
+	if !reflect.DeepEqual(args, want) {
+		t.Errorf("built args = %v, want %v", args, want)
+	}
+}


### PR DESCRIPTION
## Problem

`recon.MCPIdentifiers` and the `mcptool.*` probes synthesize tool-call arguments from a tool's JSON schema: the identifier (or payload) in the parameter under test, plus a type-derived filler for every other required parameter. That is the right default — zero config, no prior knowledge of the target.

It breaks on servers that wrap every tool behind a uniform envelope:

```json
{"action": "<enum>", "org_uid": "<tenant id>", "params": { ... }}
```

Both required top-level parameters must be exactly right — the tenant id is an opaque value no schema declares — and the parameter actually under test lives **nested inside `params`**. The synthesized flat call is rejected by argument validation before any server logic runs:

```go
// internal/recon/mcp/identifiers.go
res, err := s.inv.CallTool(ctx, en.name, requiredBenignArgs(en.params))
if err != nil || res.IsError { continue }   // <-- every tool skipped
```

The failure is silent end to end:

```
recon: all calls isError  ->  0 identifiers harvested
                                    |
mcptool.BOLA: len(identities) == 0  ->  returns 0 attempts, NO error
                                    |
                              scan reports CLEAN
```

A silently narrowed scan, not a secure target.

## Verification against a live target

Confirmed on a commercial MCP server whose 32 tools all use this shape. Exactly what `benignArgs` generates:

```
{"action":"test","org_uid":"test","params":{},"id":"<target>"}
-> isError: true
   "The org_uid provided is not one of your accounts."
```

The same call with a real discriminator, a real tenant id, and the identifier nested under `params` returns data.

Note `mcptool`'s `benignValue` is already enum-aware and would pick a valid `action`; it still cannot supply `org_uid` (no enum, no description-mined candidate) or reach into `params`. `recon`'s `benignValue` has neither.

## Change

New `internal/toolargs` with two optional per-tool hints:

| Key | Purpose |
|---|---|
| `tool_args` | static values merged **over** synthesized arguments, for params the schema cannot supply |
| `tool_id_paths` | dotted path naming where the identifier/payload belongs, so it can be nested |

```yaml
recon:
  settings:
    recon.MCPIdentifiers:
      tool_args:
        upwork__get_account:
          action: "get_user_details"
          org_uid: "2087392690628212517"
      tool_id_paths:
        upwork__get_account: "params.id"
```

Wired into `recon.MCPIdentifiers` (both call sites, via `buildGetterArgs`) and the `mcptool` probes that build arguments — `Injection`, `PathTraversal`, `SSRF` — via a shared `buildArgs` helper.

**`mcptool.BOLA` needs no change.** It replays `MCPObjectRef.Args`, so fixing recon fixes the replay envelope for free.

## Backwards compatibility

Both hints default to empty and the zero `Builder` is a no-op, so a target with no configuration keeps **byte-for-byte identical** behavior. Asserted directly:

```go
func TestBuildGetterArgsUnchangedWithoutHints(t *testing.T) {
    got  := m.buildGetterArgs(g, "TARGET")
    want := benignArgs(g.params, g.idParam, "TARGET")
    // reflect.DeepEqual
}
```

Malformed hints are skipped rather than failing construction: a bad entry must not take down a scan that is useful without it.

## Testing

- `internal/toolargs`: 11 tests — no-op paths, static override, nested placement, empty-object population, non-object intermediate replacement, per-tool scoping, deep paths, sibling preservation, nil-map safety, malformed and wrong-type config
- `internal/recon/mcp`: 4 integration tests on `buildGetterArgs` — unchanged-without-hints, full envelope, static-only, per-tool scoping
- Full suite green; `golangci-lint run` on all touched packages: 0 issues

## Reviewer notes

Two judgment calls worth a look:

`Place` replaces a **non-object** value sitting at an intermediate path step. The synthesized filler for an `object`-typed param is `map[string]any{}`, which populates correctly — but a `"test"` string there would otherwise block the path. I treated a configured path as an explicit statement about the tool's shape that outranks a filler.

Operator `tool_args` win over synthesized fillers, matching how `toolpolicy`'s explicit allow/deny outranks server annotations. They exist precisely because the filler is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
