### PR TITLE
build(go): upgrade to Go 1.27

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Go 1.25.3
-ARG GO_VERSION=1.25.3
+ARG GO_VERSION=1.27.0
 RUN curl -fsSL https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz -o /tmp/go.tar.gz && \
     rm -rf /usr/local/go && \
     tar -C /usr/local -xzf /tmp/go.tar.gz && \
@@ -35,7 +35,7 @@ ENV PATH="/usr/local/go/bin:/home/vscode/go/bin:${PATH}"
 ENV GOPATH="/home/vscode/go"
 
 # Install Go tools
-RUN GOPATH=/tmp/gotools go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest && \
+RUN GOPATH=/tmp/gotools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1 && \
     mkdir -p /home/vscode/go/bin && \
     cp /tmp/gotools/bin/* /home/vscode/go/bin/ && \
     chown -R vscode:vscode /home/vscode/go 2>/dev/null || true && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Go 1.25.3
+# Install Go 1.27.0
 ARG GO_VERSION=1.27.0
 RUN curl -fsSL https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz -o /tmp/go.tar.gz && \
     rm -rf /usr/local/go && \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: read
     with:
+      golangci-lint-version: "v2.13.1"
       build-cmd-path: ./cmd/augustus
       build-binary-name: augustus
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,4 +29,7 @@ jobs:
       contents: read
       security-events: write
       actions: read           # required by codeql-action/upload-sarif for run metadata
+    with:
+      gosec-version: "v2.28.0"
+      govulncheck-version: "v1.7.0"
     secrets: inherit

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,8 +6,8 @@
 # enforce a clean `gofmt`/`gofumpt`/`goimports` tree.
 #
 # CI runs this via praetorian-inc/public-workflows .github/workflows/go-ci.yml
-# (golangci-lint v2.12.2, enable-lint defaults to true). No workflow change is
-# needed — ci.yml and security.yml already watch `.golangci*`.
+# (golangci-lint v2.13.1, enable-lint defaults to true). ci.yml passes that
+# exact version; ci.yml and security.yml already watch `.golangci*`.
 #
 # To extend with bug-catching linters later (Tier 2: bodyclose, errorlint,
 # copyloopvar, usestdlibvars, nilerr), add them under `linters.enable` and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ make test-equiv               # Run equivalence tests (Go vs Python)
 make test-cover               # Run tests with coverage report
 
 # Lint & format
-make lint                     # Run golangci-lint per .golangci.yml (standard linters + gofumpt/goimports formatters); auto-installs the pinned version, falls back to go vet if unavailable
+make lint                     # Run the exact pinned golangci-lint version per .golangci.yml (standard linters + gofumpt/goimports formatters)
 golangci-lint fmt ./...       # Apply gofumpt + goimports formatting — matches what CI enforces (plain `go fmt` no longer satisfies the lint gate)
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ We are committed to providing a welcoming and inspiring community for all. Pleas
 
 ### Prerequisites
 
-- **Go 1.21+** - Augustus is written in Go
+- **Go 1.27.0+** - Augustus is written in Go
 - **Git** - For version control
 - **Make** - For build automation
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BINARY ?= augustus
 BUILD_DIR ?= bin
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS := -ldflags "-s -w -X main.version=$(VERSION)"
-GOLANGCI_LINT_VERSION ?= v2.12.2
+GOLANGCI_LINT_VERSION ?= v2.13.1
 
 # Auto-discover source files
 GO_SOURCES := $(shell find . -type f -name '*.go' -not -path './vendor/*')

--- a/Makefile
+++ b/Makefile
@@ -41,14 +41,7 @@ test-equiv: ## Run equivalence tests
 	$(GO) test -v ./tests/equivalence/...
 
 lint: ## Run linter (requires golangci-lint)
-	@if command -v golangci-lint >/dev/null 2>&1; then \
-		golangci-lint run ./...; \
-	elif go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) 2>/dev/null; then \
-		golangci-lint run ./...; \
-	else \
-		echo "golangci-lint not available, running go vet..."; \
-		go vet ./...; \
-	fi
+	$(GO) run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run ./...
 
 multimodal-assets-verify: ## Verify multimodal probe assets carry their canaries
 	cd tools/multimodal-assets && python3 verify.py --check-committed --repo-root ../..

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Unlike research-oriented tools, Augustus is built for production security testin
 
 ### Installation
 
-Requires Go 1.25.3 or later.
+Requires Go 1.27.0 or later.
 
 ```bash
 go install github.com/praetorian-inc/augustus/cmd/augustus@latest

--- a/docs/01 - Overview/Installation & Build.md
+++ b/docs/01 - Overview/Installation & Build.md
@@ -11,7 +11,7 @@ status: complete
 
 - **Go 1.27.0 or later** (the version pinned in `go.mod`).
 - `make` for the convenience targets (optional — you can build directly with `go`).
-- `golangci-lint v2.13.1` for linting (the `lint` target auto-installs the pinned version if missing, and falls back to `go vet`).
+- `golangci-lint v2.13.1` for linting (the `lint` target runs this exact version via `go run`).
 
 ## Install via `go install`
 
@@ -44,7 +44,7 @@ go build ./cmd/augustus
 | `make test` | Run all tests with the race detector (`go test -v -race ./...`). |
 | `make test-cover` | Run tests with coverage, emit `coverage.html`. |
 | `make test-equiv` | Run Go-vs-Python equivalence tests (`./tests/equivalence/...`). |
-| `make lint` | Run `golangci-lint run ./...`; auto-installs the pinned version, else `go vet`. |
+| `make lint` | Run the pinned `golangci-lint v2.13.1` via `go run`. |
 | `make install` | `go install ./cmd/augustus` into `$GOPATH/bin`. |
 | `make clean` | Remove `bin/`, `coverage.out`, `coverage.html`. |
 | `make help` | List available targets (default goal). |

--- a/docs/01 - Overview/Installation & Build.md
+++ b/docs/01 - Overview/Installation & Build.md
@@ -9,9 +9,9 @@ status: complete
 
 ## Prerequisites
 
-- **Go 1.25.3 or later** (the version pinned in `go.mod`).
+- **Go 1.27.0 or later** (the version pinned in `go.mod`).
 - `make` for the convenience targets (optional — you can build directly with `go`).
-- `golangci-lint v2.12.2` for linting (the `lint` target auto-installs the pinned version if missing, and falls back to `go vet`).
+- `golangci-lint v2.13.1` for linting (the `lint` target auto-installs the pinned version if missing, and falls back to `go vet`).
 
 ## Install via `go install`
 

--- a/docs/09 - Contributing/Development Setup.md
+++ b/docs/09 - Contributing/Development Setup.md
@@ -11,10 +11,10 @@ status: complete
 
 ## Prerequisites
 
-- **Go** — the module targets the version pinned in `go.mod` (`go 1.25.3`). Use that or newer.
+- **Go** — the module targets the version pinned in `go.mod` (`go 1.27.0`). Use that or newer.
 - **Git** — version control.
 - **Make** — build automation (the `Makefile` wraps the common targets).
-- **golangci-lint v2** (`v2.13.1`, pinned in the `Makefile`) — for the format/lint gate. `make lint` auto-installs the pinned version if it is missing and falls back to `go vet`.
+- **golangci-lint v2** (`v2.13.1`, pinned in the `Makefile`) — for the format/lint gate. `make lint` runs that exact version via `go run`.
 
 ## Clone
 

--- a/docs/09 - Contributing/Development Setup.md
+++ b/docs/09 - Contributing/Development Setup.md
@@ -14,7 +14,7 @@ status: complete
 - **Go** — the module targets the version pinned in `go.mod` (`go 1.25.3`). Use that or newer.
 - **Git** — version control.
 - **Make** — build automation (the `Makefile` wraps the common targets).
-- **golangci-lint v2** (`v2.12.2`, pinned in the `Makefile`) — for the format/lint gate. `make lint` auto-installs the pinned version if it is missing and falls back to `go vet`.
+- **golangci-lint v2** (`v2.13.1`, pinned in the `Makefile`) — for the format/lint gate. `make lint` auto-installs the pinned version if it is missing and falls back to `go vet`.
 
 ## Clone
 

--- a/docs/09 - Contributing/Linting, CI & Commits.md
+++ b/docs/09 - Contributing/Linting, CI & Commits.md
@@ -41,7 +41,7 @@ golangci-lint fmt ./...    # apply gofumpt + goimports (exactly what CI checks)
 make lint                  # run the standard linter set
 ```
 
-`make lint` uses an installed `golangci-lint` if present, otherwise auto-installs the pinned `v2.13.1`, and falls back to `go vet` only if installation fails.
+`make lint` runs the pinned `v2.13.1` module via `go run`, so an older binary elsewhere on `PATH` cannot be selected.
 
 ## CI
 

--- a/docs/09 - Contributing/Linting, CI & Commits.md
+++ b/docs/09 - Contributing/Linting, CI & Commits.md
@@ -11,7 +11,7 @@ status: complete
 
 ## golangci-lint v2 config
 
-`.golangci.yml` (golangci-lint **v2**, pinned to `v2.12.2` in the `Makefile`) configures two things:
+`.golangci.yml` (golangci-lint **v2**, pinned to `v2.13.1` in the `Makefile`) configures two things:
 
 ```yaml
 version: "2"
@@ -41,7 +41,7 @@ golangci-lint fmt ./...    # apply gofumpt + goimports (exactly what CI checks)
 make lint                  # run the standard linter set
 ```
 
-`make lint` uses an installed `golangci-lint` if present, otherwise auto-installs the pinned `v2.12.2`, and falls back to `go vet` only if installation fails.
+`make lint` uses an installed `golangci-lint` if present, otherwise auto-installs the pinned `v2.13.1`, and falls back to `go vet` only if installation fails.
 
 ## CI
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/praetorian-inc/augustus
 
-go 1.25.3
+go 1.27.0
 
 require (
 	github.com/Milly/go-base2048 v0.1.0

--- a/internal/recon/mcp/identifiers_test.go
+++ b/internal/recon/mcp/identifiers_test.go
@@ -696,8 +696,9 @@ type recordingInvoker struct {
 func (r *recordingInvoker) Generate(context.Context, *attempt.Conversation, int) ([]attempt.Message, error) {
 	return nil, nil
 }
-func (r *recordingInvoker) ClearHistory()                                       {}
-func (r *recordingInvoker) Name() string                                        { return "recording" }
+func (r *recordingInvoker) ClearHistory() {}
+func (r *recordingInvoker) Name() string  { return "recording" }
+
 func (r *recordingInvoker) Description() string                                 { return "recording" }
 func (r *recordingInvoker) ListTools(context.Context) ([]map[string]any, error) { return nil, nil }
 func (r *recordingInvoker) CallTool(_ context.Context, name string, _ map[string]any) (types.ToolResult, error) {


### PR DESCRIPTION
## Premise review — skipped

Mechanical toolchain migration; no new layer or abstraction.

## Summary
- raise `go.mod` and devcontainer Go to 1.27.0
- pin gosec v2.28.0, govulncheck v1.7.0, and golangci-lint v2.13.1 via existing inputs
- update current Go/lint documentation
- apply the one gofumpt change required by v2.13.1

Scanner arguments, SARIF, permissions, package coverage, and observe-only policy are unchanged. Gosec adds 6 unique reports (5 G115, 1 G703) while removing 47 old reports; no rules are suppressed. Govulncheck adds no called IDs (26 → 3).

## Verification
Exact `golang:1.27.0-bookworm`, `GOTOOLCHAIN=local`: module verify/tidy, build, vet, full tests, race, lint, gosec, govulncheck, generation drift, and multimodal asset verification. The stale `test-equiv` Make target references an absent directory and is recorded as an unrelated baseline issue.