### PR TITLE
docs: generalize AGENTS.md harness framing (ENG-5588)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This is the canonical agent instruction file for this repository. It provides guidance to any coding agent working with this code — Claude Code, Codex, and Gemini all load it. `CLAUDE.md` is a one-line pointer to this file, and `.gemini/settings.json` names it for Gemini.
 
 ## Project Overview
 


### PR DESCRIPTION
Part of [ENG-5588](https://linear.app/praetorianlabs/issue/ENG-5588/generalize-the-12-non-guard-agentsmd-files-10-still-carry-claude). Non-guard mirror of ENG-5578; intro wording matches vespasian's already-landed template (ENG-5578 has not landed on guard-core yet).

## What

Retitle `AGENTS.md` and rewrite the Claude-Code-only framing so the file is the canonical instruction file for Claude Code, Codex, and Gemini. `CLAUDE.md` stays the one-line `@AGENTS.md` pointer.

## Left untouched (ticket scope)

- Anthropic model-name / provider SKUs (constantine routing, hadrian planner table, augustus DocumentCapable)
- Merge = human decision

Fixes ENG-5588 — harness-neutral AGENTS.md framing on the 10 remaining non-guard clones; this PR is the augustus slice, the other 9 origin PRs already merged.
