### PR TITLE
ci: add instruction-file audit caller (ENG-7549)

### DIFF
--- a/.github/workflows/agents-md-audit.yml
+++ b/.github/workflows/agents-md-audit.yml
@@ -1,0 +1,16 @@
+name: Instruction-File Audit
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+concurrency:
+  group: agents-md-audit-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+jobs:
+  audit:
+    uses: praetorian-inc/public-workflows/.github/workflows/agents-md-audit.yml@a1c9243b3365df01b2ea64948f4327b4089455b0
+    permissions:
+      contents: read
+      pull-requests: write
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      RUBRIC_TOKEN: ${{ secrets.RUBRIC_TOKEN }}

--- a/.github/workflows/agents-md-audit.yml
+++ b/.github/workflows/agents-md-audit.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   audit:
-    uses: praetorian-inc/public-workflows/.github/workflows/agents-md-audit.yml@a1c9243b3365df01b2ea64948f4327b4089455b0
+    uses: praetorian-inc/public-workflows/.github/workflows/agents-md-audit.yml@a1c9243b3365df01b2ea64948f4327b4089455b0  # v2.19.1
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Part of ENG-7549

## Summary
- Add the shared instruction-file audit caller for pull requests.
- Trigger audits on opened, synchronized, and ready-for-review events with per-PR concurrency cancellation.
- Pin the reusable workflow to immutable commit `a1c9243b3365df01b2ea64948f4327b4089455b0`.

## Test evidence
- `actionlint .github/workflows/agents-md-audit.yml` (passed)

## Deployment
- `RUBRIC_TOKEN` must be provisioned as a repository Actions secret for active auditing.